### PR TITLE
Modified PgpKey.| #1157

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/security/pgp/PgpKey.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/security/pgp/PgpKey.kt
@@ -5,25 +5,14 @@
 
 package com.flowcrypt.email.security.pgp
 
-import com.flowcrypt.email.api.retrofit.response.model.node.MsgBlock
 import com.flowcrypt.email.extensions.pgp.armor
 import com.flowcrypt.email.extensions.pgp.toNodeKeyDetails
-import org.bouncycastle.bcpg.ArmoredInputStream
 import org.bouncycastle.openpgp.PGPKeyRing
-import org.bouncycastle.openpgp.PGPObjectFactory
-import org.bouncycastle.openpgp.PGPPublicKey
-import org.bouncycastle.openpgp.PGPPublicKeyRing
-import org.bouncycastle.openpgp.PGPSecretKey
 import org.bouncycastle.openpgp.PGPSecretKeyRing
-import org.bouncycastle.openpgp.PGPSignature
-import org.bouncycastle.openpgp.jcajce.JcaPGPPublicKeyRingCollection
-import org.bouncycastle.openpgp.jcajce.JcaPGPSecretKeyRingCollection
-import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator
 import org.pgpainless.PGPainless
 import org.pgpainless.key.collection.PGPKeyRingCollection
 import org.pgpainless.util.Passphrase
 import java.io.InputStream
-import java.nio.charset.StandardCharsets
 
 @Suppress("unused")
 object PgpKey {
@@ -102,102 +91,10 @@ object PgpKey {
     if (parseKeyResult.getAllKeys().isEmpty()) {
       throw IllegalArgumentException("Keys not found")
     }
-    if (parseKeyResult.pgpKeyRingCollection.pgpSecretKeyRingCollection.first() is PGPSecretKeyRing)
+    if (parseKeyResult.pgpKeyRingCollection.pgpSecretKeyRingCollection.firstOrNull() is PGPSecretKeyRing)
       return parseKeyResult.pgpKeyRingCollection.pgpSecretKeyRingCollection.first()
     else
       throw IllegalArgumentException("Key is not a secret key")
-  }
-
-  private fun parseAndNormalizeKeyRings(armored: String): List<PGPKeyRing> {
-    val normalizedArmored = PgpArmor.normalize(armored, MsgBlock.Type.UNKNOWN)
-    val keys = mutableListOf<PGPKeyRing>()
-    if (PgpArmor.ARMOR_HEADER_DICT_REGEX[MsgBlock.Type.PUBLIC_KEY]!!
-            .beginRegexp.containsMatchIn(normalizedArmored)) {
-      val keyRingCollection = JcaPGPPublicKeyRingCollection(
-          ArmoredInputStream(normalizedArmored.toByteArray(StandardCharsets.UTF_8).inputStream())
-      )
-      // We have to use reflection because BouncyCastle declares "order" list as a private field
-      // https://stackoverflow.com/a/1196207/1540501
-      // Sent a request to BouncyCastle mailing list to make this possible in a better way.
-      val orderField = keyRingCollection.javaClass.superclass!!.getDeclaredField("order")
-      orderField.isAccessible = true
-      keys.addAll(
-          (orderField.get(keyRingCollection) as java.util.List<java.lang.Long>).map {
-            keyRingCollection.getPublicKeyRing(it.toLong())!!
-          }
-      )
-    } else if (PgpArmor.ARMOR_HEADER_DICT_REGEX[MsgBlock.Type.PRIVATE_KEY]!!
-            .beginRegexp.containsMatchIn(normalizedArmored)) {
-      val keyRingCollection = JcaPGPSecretKeyRingCollection(
-          ArmoredInputStream(normalizedArmored.toByteArray(StandardCharsets.UTF_8).inputStream())
-      )
-      // Again, use reflection because BouncyCastle declares "order" list as a private field.
-      val orderField = keyRingCollection.javaClass.superclass!!.getDeclaredField("order")
-      orderField.isAccessible = true
-      keys.addAll(
-          (orderField.get(keyRingCollection) as java.util.List<java.lang.Long>).map {
-            keyRingCollection.getSecretKeyRing(it.toLong())!!
-          }
-      )
-    } else if (PgpArmor.ARMOR_HEADER_DICT_REGEX[MsgBlock.Type.ENCRYPTED_MSG]!!
-            .beginRegexp.containsMatchIn(normalizedArmored)) {
-      val objectFactory = PGPObjectFactory(
-          ArmoredInputStream(normalizedArmored.toByteArray(StandardCharsets.UTF_8).inputStream()),
-          JcaKeyFingerprintCalculator()
-      )
-      while (true) {
-        val obj = objectFactory.nextObject() ?: break
-        if (obj is PGPKeyRing) {
-          keys.add(obj)
-        }
-      }
-    }
-
-    // Prevent key bloat by removing all non-self certifications
-    for ((keyRingIndex, keyRing) in keys.withIndex()) {
-      val primaryKeyID = keyRing.publicKey.keyID
-      if (keyRing is PGPPublicKeyRing) {
-        var replacementKeyRing: PGPPublicKeyRing = keyRing
-        for (publicKey in keyRing.publicKeys) {
-          var replacementKey = publicKey
-          for (sig in publicKey.signatures.asSequence().map { it as PGPSignature }.filter {
-            it.isCertification && it.keyID != primaryKeyID
-          }) {
-            replacementKey = PGPPublicKey.removeCertification(replacementKey, sig)
-          }
-          if (replacementKey !== publicKey) {
-            replacementKeyRing = PGPPublicKeyRing.insertPublicKey(
-                replacementKeyRing, replacementKey
-            )
-          }
-        }
-        if (replacementKeyRing !== keyRing) {
-          keys[keyRingIndex] = replacementKeyRing
-        }
-      } else if (keyRing is PGPSecretKeyRing) {
-        var replacementKeyRing: PGPSecretKeyRing = keyRing
-        for (secretKey in keyRing.secretKeys) {
-          val publicKey = secretKey.publicKey
-          var replacementPublicKey = publicKey
-          for (sig in publicKey.signatures.asSequence().map { it as PGPSignature }.filter {
-            it.isCertification && it.keyID != primaryKeyID
-          }) {
-            replacementPublicKey = PGPPublicKey.removeCertification(replacementPublicKey, sig)
-          }
-          if (replacementPublicKey !== publicKey) {
-            val replacementKey = PGPSecretKey.replacePublicKey(secretKey, replacementPublicKey)
-            replacementKeyRing = PGPSecretKeyRing.insertSecretKey(
-                replacementKeyRing, replacementKey
-            )
-          }
-        }
-        if (replacementKeyRing !== keyRing) {
-          keys[keyRingIndex] = replacementKeyRing
-        }
-      }
-    }
-
-    return keys
   }
 
   data class ParseKeyResult(val pgpKeyRingCollection: PGPKeyRingCollection) {


### PR DESCRIPTION
This PR refactors `PgpKey` class. Modified `PgpKey.extractSecretKeyRing` to use `PGPainless` realization for the key parsing.
I'm not sure that those changes fix #1157, but after them, the issue will not contain a valid `stacktrace`. And I'd like to drop an own realization for the key parsing. It'll be better to use `PGPainless` for that and fix errors there.

close #1157 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
