### PR TITLE
add exempt domains to gh action

### DIFF
--- a/.github/workflows/check-for-emails.yml
+++ b/.github/workflows/check-for-emails.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Scan comment
       id: scan
-      uses: seisvelas/comment-email-address-alerts@v8
+      uses: seisvelas/comment-email-address-alerts@v2.4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        exemptions: test,example.com


### PR DESCRIPTION
This PR exempts certain domains from email monitoring in comments (per @DenBond7  feedback in https://github.com/FlowCrypt/flowcrypt-android/issues/1238). It also changes the name of the action from main.yml (per @Limonte's feedback in https://github.com/FlowCrypt/flowcrypt-browser/pull/3645)

As is, this exempts addresses that end in 'test' and 'example.com', but that can be modified however we like, so just let me know.

close https://github.com/FlowCrypt/flowcrypt-security/issues/128

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
