### PR TITLE
Migrated to use Java 11 as a default JDK.| #1376

### DIFF
--- a/FlowCrypt/build.gradle
+++ b/FlowCrypt/build.gradle
@@ -236,8 +236,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility rootProject.ext.javaSourceCompatibility
-        targetCompatibility rootProject.ext.javaSourceCompatibility
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -245,7 +245,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         //need for ACRA, maybe will be deleted in the upcoming updates
         freeCompilerArgs = ['-Xjvm-default=enable']
     }

--- a/ext.gradle
+++ b/ext.gradle
@@ -12,7 +12,6 @@ ext {
     compileSdkVersion = 30
     targetSdkVersion = 30
     minSdkVersion = 26
-    javaSourceCompatibility = '1.8'
     /*https://developer.android.com/jetpack/androidx/androidx-rn*/
     androidxBaseVersion = '1.0.0'
     /* https://developer.android.com/jetpack/androidx/releases/recyclerview*/


### PR DESCRIPTION
This PR added migration to Java 11

close #1376 
----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
