### PR TITLE
Prevented crashes for existing prv keys that uses SHA1 hash algo.| #1431

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/security/KeysStorageImpl.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/security/KeysStorageImpl.kt
@@ -71,9 +71,8 @@ class KeysStorageImpl private constructor(context: Context) : KeysStorage {
     liveData {
       val combinedSource =
         it.joinToString(separator = "\n") { keyEntity -> keyEntity.privateKeyAsString }
-      val parseKeyResult = PgpKey.parseKeys(combinedSource)
-      val keys = parseKeyResult.pgpKeyRingCollection.pgpSecretKeyRingCollection.keyRings
-        .asSequence().toList()
+      val pgpKeyRingCollection = PgpKey.parseKeysRaw(combinedSource)
+      val keys = pgpKeyRingCollection.pgpSecretKeyRingCollection.keyRings.asSequence().toList()
       emit(keys)
     }
   }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/security/pgp/PgpKey.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/security/pgp/PgpKey.kt
@@ -85,8 +85,22 @@ object PgpKey {
     throwExceptionIfUnknownSource: Boolean = true
   ): ParseKeyResult {
     return ParseKeyResult(
-      PGPainless.readKeyRing().keyRingCollection(source, throwExceptionIfUnknownSource)
+      parseKeysRaw(source, throwExceptionIfUnknownSource)
     )
+  }
+
+  fun parseKeysRaw(
+    source: String,
+    throwExceptionIfUnknownSource: Boolean = true
+  ): PGPKeyRingCollection {
+    return parseKeysRaw(source.toInputStream(), throwExceptionIfUnknownSource)
+  }
+
+  fun parseKeysRaw(
+    source: InputStream,
+    throwExceptionIfUnknownSource: Boolean = true
+  ): PGPKeyRingCollection {
+    return PGPainless.readKeyRing().keyRingCollection(source, throwExceptionIfUnknownSource)
   }
 
   fun decryptKey(key: PGPSecretKeyRing, passphrase: Passphrase): PGPSecretKeyRing {


### PR DESCRIPTION
This PR added a code that prevents crashes for users who use prv keys with SHA1 hash algo

close #1431

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
