### PR TITLE
Issue 1928 fix visibility of btnsetwebportalpassword

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
@@ -1258,7 +1258,9 @@ class CreateMessageFragment : BaseFragment<FragmentCreateMessageBinding>(),
         if (isPasswordProtectedFunctionalityEnabled()) {
           val hasRecipientsWithoutPgp =
             recipients.any { recipient -> !recipient.value.recipientWithPubKeys.hasAtLeastOnePubKey() }
-          if (hasRecipientsWithoutPgp) {
+          if (hasRecipientsWithoutPgp &&
+            composeMsgViewModel.msgEncryptionType == MessageEncryptionType.ENCRYPTED
+          ) {
             binding?.btnSetWebPortalPassword?.visible()
           } else {
             binding?.btnSetWebPortalPassword?.gone()

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
@@ -217,6 +217,7 @@ class CreateMessageFragment : BaseFragment<FragmentCreateMessageBinding>(),
 
   private var isIncomingMsgInfoUsed: Boolean = false
   private var isMsgSentToQueue: Boolean = false
+  private var updatingRecipientsMarker: Boolean = false
   private var originalColor: Int = 0
 
   override fun onAttach(context: Context) {
@@ -1255,6 +1256,11 @@ class CreateMessageFragment : BaseFragment<FragmentCreateMessageBinding>(),
 
     lifecycleScope.launchWhenStarted {
       composeMsgViewModel.recipientsStateFlow.collect { recipients ->
+        if (recipients.any { it.value.isUpdating } && !updatingRecipientsMarker) {
+          updatingRecipientsMarker = true
+          countingIdlingResource?.incrementSafely()
+        }
+
         if (isPasswordProtectedFunctionalityEnabled()) {
           val hasRecipientsWithoutPgp =
             recipients.any { recipient -> !recipient.value.recipientWithPubKeys.hasAtLeastOnePubKey() }
@@ -1266,6 +1272,11 @@ class CreateMessageFragment : BaseFragment<FragmentCreateMessageBinding>(),
             binding?.btnSetWebPortalPassword?.gone()
             composeMsgViewModel.setWebPortalPassword()
           }
+        }
+
+        if (recipients.none { it.value.isUpdating }) {
+          updatingRecipientsMarker = false
+          countingIdlingResource?.decrementSafely()
         }
       }
     }


### PR DESCRIPTION
This PR Fixed visibility of btnSetWebPortalPassword when we use a standard mode

close #1928

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why). Updating recipients is an async operation. For such a case we use Espresso idling, it waits while the async operation will be completed. But to test this issue we have to switch to the "Encrypted mode" while the app updates recipients. Anyway, it was tested manually.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
