### PR TITLE
Issue 2021 notification runtime permission

### DIFF
--- a/FlowCrypt/src/main/AndroidManifest.xml
+++ b/FlowCrypt/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
     <!-- Request the foreground service permission. Details here
      https://developer.android.com/guide/components/foreground-services#request-foreground-service-permissions -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!--Starting from Android 13 (API level 33) the app has to ask a user permission to show any notifications
+    https://developer.android.com/develop/ui/views/notifications/notification-permission-->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".FlowCryptApplication"

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/preferences/NotificationsSettingsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/preferences/NotificationsSettingsFragment.kt
@@ -5,11 +5,16 @@
 
 package com.flowcrypt.email.ui.activity.fragment.preferences
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.setFragmentResultListener
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceManager
@@ -17,8 +22,10 @@ import com.flowcrypt.email.BuildConfig
 import com.flowcrypt.email.Constants
 import com.flowcrypt.email.R
 import com.flowcrypt.email.database.entity.AccountEntity
+import com.flowcrypt.email.extensions.showTwoWayDialog
 import com.flowcrypt.email.ui.activity.MainActivity
 import com.flowcrypt.email.ui.activity.fragment.base.BasePreferenceFragment
+import com.flowcrypt.email.ui.activity.fragment.dialog.TwoWayDialogFragment
 import com.flowcrypt.email.util.SharedPreferencesHelper
 
 /**
@@ -36,6 +43,23 @@ open class NotificationsSettingsFragment : BasePreferenceFragment(),
   private var levels: Array<CharSequence>? = null
   private var entries: Array<String>? = null
 
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+      ContextCompat.checkSelfPermission(
+        requireContext(),
+        Manifest.permission.POST_NOTIFICATIONS
+      ) != PackageManager.PERMISSION_GRANTED
+    ) {
+      showTwoWayDialog(
+        requestCode = REQUEST_CODE_ASK_POST_NOTIFICATIONS_PERMISSION,
+        dialogMsg = getString(R.string.need_post_notification_permission),
+        positiveButtonTitle = getString(R.string.manage_notifications),
+        negativeButtonTitle = getString(R.string.cancel),
+      )
+    }
+  }
+
   override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
     setPreferencesFromResource(R.xml.preferences_notifications_settings, rootKey)
   }
@@ -43,15 +67,14 @@ open class NotificationsSettingsFragment : BasePreferenceFragment(),
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     (activity as AppCompatActivity?)?.supportActionBar?.title = getString(R.string.notifications)
+
+    subscribeToTwoWayDialog()
   }
 
   override fun onPreferenceClick(preference: Preference): Boolean {
     return when (preference.key) {
       Constants.PREF_KEY_MANAGE_NOTIFICATIONS -> {
-        val intent = Intent()
-        intent.action = Settings.ACTION_APP_NOTIFICATION_SETTINGS
-        intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
-        startActivity(intent)
+        openSettings()
         true
       }
 
@@ -124,9 +147,32 @@ open class NotificationsSettingsFragment : BasePreferenceFragment(),
     filter.summary = generateSummary(currentValue!!, filter.entryValues, filter.entries)
   }
 
+  private fun subscribeToTwoWayDialog() {
+    setFragmentResultListener(TwoWayDialogFragment.REQUEST_KEY_BUTTON_CLICK) { _, bundle ->
+      val requestCode = bundle.getInt(TwoWayDialogFragment.KEY_REQUEST_CODE)
+      val result = bundle.getInt(TwoWayDialogFragment.KEY_RESULT)
+
+      when (requestCode) {
+        REQUEST_CODE_ASK_POST_NOTIFICATIONS_PERMISSION -> {
+          if (result == TwoWayDialogFragment.RESULT_OK) {
+            openSettings()
+          }
+        }
+      }
+    }
+  }
+
+  private fun openSettings() {
+    val intent = Intent()
+    intent.action = Settings.ACTION_APP_NOTIFICATION_SETTINGS
+    intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
+    startActivity(intent)
+  }
+
   companion object {
     const val NOTIFICATION_LEVEL_ALL_MESSAGES = "all_messages"
     const val NOTIFICATION_LEVEL_ENCRYPTED_MESSAGES_ONLY = "encrypted_messages_only"
     const val NOTIFICATION_LEVEL_NEVER = "never"
+    private const val REQUEST_CODE_ASK_POST_NOTIFICATIONS_PERMISSION = 10
   }
 }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/preferences/SecuritySettingsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/preferences/SecuritySettingsFragment.kt
@@ -13,13 +13,13 @@ import com.flowcrypt.email.Constants
 import com.flowcrypt.email.R
 import com.flowcrypt.email.extensions.getNavigationResult
 import com.flowcrypt.email.extensions.navController
+import com.flowcrypt.email.extensions.showInfoDialog
 import com.flowcrypt.email.extensions.showNeedPassphraseDialog
 import com.flowcrypt.email.extensions.supportActionBar
 import com.flowcrypt.email.security.KeysStorageImpl
 import com.flowcrypt.email.ui.activity.fragment.RecheckProvidedPassphraseFragment
 import com.flowcrypt.email.ui.activity.fragment.base.BasePreferenceFragment
 import com.flowcrypt.email.ui.activity.fragment.dialog.FixNeedPassphraseIssueDialogFragment
-import com.flowcrypt.email.util.UIUtil
 
 /**
  * This fragment contains actions which related to Security options.
@@ -49,8 +49,8 @@ class SecuritySettingsFragment : BasePreferenceFragment(), Preference.OnPreferen
       Constants.PREF_KEY_SECURITY_CHANGE_PASS_PHRASE -> {
         val keysStorage = KeysStorageImpl.getInstance(requireContext())
         if (keysStorage.getRawKeys().isEmpty()) {
-          UIUtil.showInfoSnackbar(
-            requireView(), getString(
+          showInfoDialog(
+            dialogMsg = getString(
               R.string.account_has_no_associated_keys,
               getString(R.string.support_email)
             )

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/util/UIUtil.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/util/UIUtil.kt
@@ -15,7 +15,6 @@ import android.text.TextUtils
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
-import com.google.android.material.snackbar.Snackbar
 import java.io.ByteArrayOutputStream
 
 /**
@@ -28,40 +27,6 @@ import java.io.ByteArrayOutputStream
  */
 class UIUtil {
   companion object {
-    /**
-     * Show some information as Snackbar.
-     *
-     * @param view    The view to find a parent from.
-     * @param msgText The text to show.  Can be formatted text..
-     */
-    fun showInfoSnackbar(view: View, msgText: String): Snackbar {
-      val snackbar = Snackbar.make(view, msgText, Snackbar.LENGTH_INDEFINITE)
-        .setAction(android.R.string.ok) { }
-      snackbar.show()
-
-      return snackbar
-    }
-
-    /**
-     * Show some information as Snackbar with custom message, action button mame and listener. .
-     *
-     * @param view            The view to find a parent from.
-     * @param msgText         The text to show.  Can be formatted text..
-     * @param buttonName      The text of the Snackbar button;
-     * @param onClickListener The Snackbar button click listener.
-     * @param duration        How long to display the message. Either [Snackbar.LENGTH_SHORT] or [Snackbar.LENGTH_LONG]
-     */
-    @JvmOverloads
-    fun showSnackbar(
-      view: View, msgText: String, buttonName: String,
-      onClickListener: View.OnClickListener, duration: Int = Snackbar.LENGTH_INDEFINITE
-    ): Snackbar {
-      val snackbar = Snackbar.make(view, msgText, duration).setAction(buttonName, onClickListener)
-      snackbar.show()
-
-      return snackbar
-    }
-
     /**
      * Request to hide the soft input window from the
      * context of the window that is currently accepting input.

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -491,4 +491,7 @@
     <string name="no_recipients">(без получателей)</string>
     <string name="could_not_save_draft">Не удалось сохранить черновик\n\nДетали ошибки:\n%1$s</string>
     <string name="can_not_replace_public_key_at_attester">Невозможно заменить публичный ключ на сервере attester. Правила организации запрещают это.</string>
+    <string name="cannot_show_notifications_without_permission">Отображение уведомлений не включено в приложении</string>
+    <string name="need_post_notification_permission">Нам нужно разрешение, чтобы показывать уведомления о новых сообщениях</string>
+    <string name="ask">Спросить</string>
 </resources>

--- a/FlowCrypt/src/main/res/values-uk/strings.xml
+++ b/FlowCrypt/src/main/res/values-uk/strings.xml
@@ -492,4 +492,7 @@
     <string name="no_recipients">(без отримувачів)</string>
     <string name="could_not_save_draft">Не вдалося зберегти чорновик\n\nДеталі помилки:\n%1$s</string>
     <string name="can_not_replace_public_key_at_attester">Неможливо замінити публічний ключ на сервері attester. Правила організації забороняють це.</string>
+    <string name="cannot_show_notifications_without_permission">У додатку не ввімкнено показ сповіщень</string>
+    <string name="need_post_notification_permission">Нам потрібен дозвіл, щоб показувати сповіщення про нові листи</string>
+    <string name="ask">Запитати</string>
 </resources>

--- a/FlowCrypt/src/main/res/values/strings.xml
+++ b/FlowCrypt/src/main/res/values/strings.xml
@@ -577,4 +577,7 @@
     <string name="no_recipients">(no recipients)</string>
     <string name="could_not_save_draft">Could not save a draft\n\nError details:\n%1$s</string>
     <string name="can_not_replace_public_key_at_attester">Cannot replace public key at attester because your organisation rules forbid it.</string>
+    <string name="cannot_show_notifications_without_permission">Showing notifications is not enabled in the app</string>
+    <string name="need_post_notification_permission">We need permission to show notifications about new messages</string>
+    <string name="ask">Ask</string>
 </resources>


### PR DESCRIPTION
This PR added support of Notification runtime permission for Android 13 (API level 33) and high

close #2021

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (issue #2022)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
