### PR TITLE
Issue 2155 semaphore ci fix dns for localhost

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,7 +25,13 @@ global_job_config:
       value: /home/semaphore/Android/Sdk
   prologue:
     commands:
+      # fix DNS issue for localhost
+      - sudo apt install -y dnsmasq
+      - sudo sed -i '1s/^/nameserver 127.0.0.53\n/' /etc/resolv.conf
+      - sudo service systemd-resolved restart
+      # use JAVA 11 by default
       - sem-version java 11
+      # general settings
       - export PATH=${ANDROID_SDK_ROOT}/emulator:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${ANDROID_SDK_ROOT}/platform-tools:${PATH}
       - sudo rm -rf ~/.rbenv ~/.phpbrew
       - checkout

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -29,6 +29,9 @@ global_job_config:
       - sudo apt install -y dnsmasq
       - sudo sed -i '1s/^/nameserver 127.0.0.53\n/' /etc/resolv.conf
       - sudo service systemd-resolved restart
+      # print some debug info
+      - sudo service dnsmasq status
+      - ping fel.localhost -c 1
       # use JAVA 11 by default
       - sem-version java 11
       # general settings

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,7 +30,8 @@ global_job_config:
       - sudo sed -i '1s/^/nameserver 127.0.0.53\n/' /etc/resolv.conf
       - sudo service systemd-resolved restart
       # print some debug info
-      - sudo service dnsmasq status
+      - sudo systemctl status dnsmasq
+      - sudo journalctl -u dnsmasq -n 5
       - ping fel.localhost -c 1
       # use JAVA 11 by default
       - sem-version java 11

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,7 +30,6 @@ global_job_config:
       - sudo sed -i '1s/^/nameserver 127.0.0.53\n/' /etc/resolv.conf
       - sudo service systemd-resolved restart
       # print some debug info
-      - sudo journalctl -u dnsmasq -n 5
       - ping fel.localhost -c 1
       # use JAVA 11 by default
       - sem-version java 11

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: FlowCrypt Android App
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 execution_time_limit:
   minutes: 60
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,7 +30,6 @@ global_job_config:
       - sudo sed -i '1s/^/nameserver 127.0.0.53\n/' /etc/resolv.conf
       - sudo service systemd-resolved restart
       # print some debug info
-      - sudo systemctl status dnsmasq
       - sudo journalctl -u dnsmasq -n 5
       - ping fel.localhost -c 1
       # use JAVA 11 by default

--- a/script/ci-setup-and-run-emulator.sh
+++ b/script/ci-setup-and-run-emulator.sh
@@ -7,4 +7,4 @@ cat ~/.android/avd/ci-emulator.avd/config.ini
 # echo "hw.ramSize=3064"  >> ~/.android/avd/ci-emulator.avd/config.ini
 # cat ~/.android/avd/ci-emulator.avd/config.ini
 "$ANDROID_SDK_ROOT/emulator/emulator" -list-avds #debug
-"$ANDROID_SDK_ROOT/emulator/emulator" -avd ci-emulator -no-window -no-boot-anim -no-audio -gpu auto -writable-system &
+"$ANDROID_SDK_ROOT/emulator/emulator" -avd ci-emulator -no-window -no-boot-anim -no-audio -gpu auto -read-only &

--- a/script/ci-wait-for-emulator.sh
+++ b/script/ci-wait-for-emulator.sh
@@ -8,23 +8,10 @@ adb shell settings put global transition_animation_scale 0
 adb shell settings put global animator_duration_scale 0
 
 ###################################################################################################
-# on SemaphoreCI ping fes.localhost on an emulator returns 'unknown host fes.localhost'.
-# Need to change /etc/hosts
-adb root
-# Need wait for the root environment
-sleep 20
-adb remount # Use this option to have a writable system image during an emulation session
-adb reboot
-# Need to wait the device reboot.
-adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'
-adb root
-adb remount
-# Need wait for the root environment
-sleep 20
-# Changing /etc/hosts
-adb shell "echo \"127.0.0.1  fes.localhost\" >> /etc/hosts"
-
 # to test WKD we need to route all traffic for localhost to localhost:1212
+adb root
+# Need wait for the root environment
+sleep 20
 adb shell "echo 1 > /proc/sys/net/ipv4/ip_forward"
 adb shell "iptables -t nat -A PREROUTING -s 127.0.0.1 -p tcp --dport 443 -j REDIRECT --to 1212"
 adb shell "iptables -t nat -A OUTPUT -s 127.0.0.1 -p tcp --dport 443 -j REDIRECT --to 1212"


### PR DESCRIPTION
This PR fixed resolving `fes.localhost` by Android Emulator on `Semaphore CI`.

close #2155

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
