### PR TITLE
more tests for FES login

### DIFF
--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/DraftsGmailAPITestCorrectDeletingFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/DraftsGmailAPITestCorrectDeletingFlowTest.kt
@@ -41,6 +41,7 @@ import com.flowcrypt.email.rules.ScreenshotTestRule
 import com.flowcrypt.email.ui.base.BaseDraftsGmailAPIFlowTest
 import com.flowcrypt.email.util.AccountDaoManager
 import com.flowcrypt.email.viewaction.CustomViewActions.swipeToRefresh
+import com.google.api.client.json.Json
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.gmail.model.History
 import com.google.api.services.gmail.model.HistoryMessageDeleted
@@ -88,7 +89,7 @@ class DraftsGmailAPITestCorrectDeletingFlowTest : BaseDraftsGmailAPIFlowTest() {
               "&format=full" -> {
 
             MockResponse().setResponseCode(HttpURLConnection.HTTP_OK)
-              .setHeader("Content-Type", "application/json; charset=UTF-8")
+              .setHeader("Content-Type", Json.MEDIA_TYPE)
               .setBody(
                 genMessage(
                   messageId = MESSAGE_ID_FIRST,
@@ -107,7 +108,7 @@ class DraftsGmailAPITestCorrectDeletingFlowTest : BaseDraftsGmailAPIFlowTest() {
               "&format=full" -> {
 
             MockResponse().setResponseCode(HttpURLConnection.HTTP_OK)
-              .setHeader("Content-Type", "application/json; charset=UTF-8")
+              .setHeader("Content-Type", Json.MEDIA_TYPE)
               .setBody(
                 genMessage(
                   messageId = MESSAGE_ID_SECOND,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/MainSignInFragmentEnterpriseFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/MainSignInFragmentEnterpriseFlowTest.kt
@@ -371,6 +371,23 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
   }
 
   @Test
+  fun testCallFesServerForEnterpriseUser() {
+    setupAndClickSignInButton(genMockGoogleSignInAccountJson(EMAIL_ENTERPRISE_USER))
+
+    //the mock web server should return error for https://fes.$domain/api/
+    isDialogWithTextDisplayed(
+      decorView,
+      "ApiException:" + ApiException(
+        ApiError(
+          code = HttpURLConnection.HTTP_UNAUTHORIZED,
+          msg = ""
+        )
+      ).message!!
+    )
+    //after this we will be sure that https://fes.$domain/api/ was called for an enterprise user
+  }
+
+  @Test
   fun testFesServerUpGetClientConfigurationFailed() {
     setupAndClickSignInButton(
       genMockGoogleSignInAccountJson(EMAIL_FES_CLIENT_CONFIGURATION_FAILED)
@@ -469,13 +486,15 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
       "testFesServerUpGetClientConfigurationFailed" -> HttpURLConnection.HTTP_FORBIDDEN
       "testFesServerExternalServiceAlias" -> HttpURLConnection.HTTP_NOT_ACCEPTABLE
       "testFesServerEnterpriseServerAlias" -> HttpURLConnection.HTTP_CONFLICT
+      "testCallFesServerForEnterpriseUser" -> HttpURLConnection.HTTP_UNAUTHORIZED
       else -> HttpURLConnection.HTTP_OK
     }
 
     val body = when (testNameRule.methodName) {
       "testFesServerUpGetClientConfigurationFailed",
       "testFesServerExternalServiceAlias",
-      "testFesServerEnterpriseServerAlias" -> null
+      "testFesServerEnterpriseServerAlias",
+      "testCallFesServerForEnterpriseUser" -> null
       else -> gson.toJson(
         ClientConfigurationResponse(
           clientConfiguration = ClientConfiguration(
@@ -690,6 +709,7 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
       "fes_client_configuration_failed@localhost:1212"
     private const val EMAIL_FES_ENFORCE_ATTESTER_SUBMIT =
       "enforce_attester_submit@localhost:1212"
+    private const val EMAIL_ENTERPRISE_USER = "enterprise_user@localhost:1212"
 
     private const val EMAIL_GMAIL = "gmail@gmail.com"
     private const val EMAIL_GOOGLEMAIL = "googlemail@googlemail.com"

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/MainSignInFragmentEnterpriseFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/MainSignInFragmentEnterpriseFlowTest.kt
@@ -54,6 +54,7 @@ import org.junit.rules.TestName
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import java.net.HttpURLConnection
+import java.util.concurrent.TimeUnit
 
 /**
  * @author Denis Bondarenko
@@ -293,28 +294,28 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
   }
 
   @Test
-  fun testFesAvailabilityServerUpRequestTimeOut() {
+  fun testFesAvailabilityServerAvailableRequestTimeOutHasConnection() {
     setupAndClickSignInButton(genMockGoogleSignInAccountJson(EMAIL_FES_REQUEST_TIME_OUT))
     onView(withText(R.string.set_pass_phrase))
       .check(matches(isDisplayed()))
   }
 
   @Test
-  fun testFesServerUpHasConnectionHttpCode404() {
+  fun testFesServerAvailableHasConnectionHttpCode404() {
     setupAndClickSignInButton(genMockGoogleSignInAccountJson(EMAIL_FES_HTTP_404))
     onView(withText(R.string.set_pass_phrase))
       .check(matches(isDisplayed()))
   }
 
   @Test
-  fun testFesServerUpHasConnectionHttpCodeNotSuccess() {
+  fun testFesServerAvailableHasConnectionHttpCodeNotSuccess() {
     setupAndClickSignInButton(genMockGoogleSignInAccountJson(EMAIL_FES_HTTP_NOT_404_NOT_SUCCESS))
     onView(withText(R.string.set_pass_phrase))
       .check(matches(isDisplayed()))
   }
 
   @Test
-  fun testFesServerNotEnterpriseServer() {
+  fun testFesServerIsNotEnterpriseServer() {
     setupAndClickSignInButton(genMockGoogleSignInAccountJson(email = EMAIL_FES_NOT_ALLOWED_SERVER))
 
     isDialogWithTextDisplayed(
@@ -362,7 +363,7 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
   }
 
   @Test
-  fun testFesServerUpGetClientConfigurationSuccess() {
+  fun testFesServerAvailableGetClientConfigurationSuccess() {
     setupAndClickSignInButton(
       genMockGoogleSignInAccountJson(EMAIL_FES_CLIENT_CONFIGURATION_SUCCESS)
     )
@@ -388,7 +389,7 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
   }
 
   @Test
-  fun testFesServerUpGetClientConfigurationFailed() {
+  fun testFesServerAvailableGetClientConfigurationFailed() {
     setupAndClickSignInButton(
       genMockGoogleSignInAccountJson(EMAIL_FES_CLIENT_CONFIGURATION_FAILED)
     )
@@ -443,23 +444,21 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
   }
 
   private fun handleFesAvailabilityAPI(gson: Gson): MockResponse {
-    return if (testNameRule.methodName == "testFesAvailabilityServerUpRequestTimeOut") {
-      val delayInMilliseconds = 6000
-      val initialTimeMillis = System.currentTimeMillis()
-      while (System.currentTimeMillis() - initialTimeMillis <= delayInMilliseconds) {
-        Thread.sleep(100)
-      }
+    return if ("testFesAvailabilityServerAvailableRequestTimeOutHasConnection" ==
+      testNameRule.methodName
+    ) {
       MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
+        .setHeadersDelay(6, TimeUnit.SECONDS)
     } else when (testNameRule.methodName) {
-      "testFesServerUpHasConnectionHttpCode404", "testFailAttesterSubmit" -> {
+      "testFesServerAvailableHasConnectionHttpCode404", "testFailAttesterSubmit" -> {
         MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
       }
 
-      "testFesServerUpHasConnectionHttpCodeNotSuccess" -> {
+      "testFesServerAvailableHasConnectionHttpCodeNotSuccess" -> {
         MockResponse().setResponseCode(500)
       }
 
-      "testFesServerNotEnterpriseServer" -> {
+      "testFesServerIsNotEnterpriseServer" -> {
         MockResponse().setResponseCode(HttpURLConnection.HTTP_OK)
           .setBody(gson.toJson(FES_SUCCESS_RESPONSE.copy(service = "hello")))
       }
@@ -483,7 +482,7 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
 
   private fun handleClientConfigurationAPI(gson: Gson): MockResponse {
     val responseCode = when (testNameRule.methodName) {
-      "testFesServerUpGetClientConfigurationFailed" -> HttpURLConnection.HTTP_FORBIDDEN
+      "testFesServerAvailableGetClientConfigurationFailed" -> HttpURLConnection.HTTP_FORBIDDEN
       "testFesServerExternalServiceAlias" -> HttpURLConnection.HTTP_NOT_ACCEPTABLE
       "testFesServerEnterpriseServerAlias" -> HttpURLConnection.HTTP_CONFLICT
       "testCallFesServerForEnterpriseUser" -> HttpURLConnection.HTTP_UNAUTHORIZED
@@ -491,7 +490,7 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
     }
 
     val body = when (testNameRule.methodName) {
-      "testFesServerUpGetClientConfigurationFailed",
+      "testFesServerAvailableGetClientConfigurationFailed",
       "testFesServerExternalServiceAlias",
       "testFesServerEnterpriseServerAlias",
       "testCallFesServerForEnterpriseUser" -> null

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/MainSignInFragmentEnterpriseFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/MainSignInFragmentEnterpriseFlowTest.kt
@@ -372,7 +372,7 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
   }
 
   @Test
-  fun testCallFesServerForEnterpriseUser() {
+  fun testCallFesUrlToGetClientConfigurationForEnterpriseUser() {
     setupAndClickSignInButton(genMockGoogleSignInAccountJson(EMAIL_ENTERPRISE_USER))
 
     //the mock web server should return error for https://fes.$domain/api/
@@ -485,7 +485,7 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
       "testFesServerAvailableGetClientConfigurationFailed" -> HttpURLConnection.HTTP_FORBIDDEN
       "testFesServerExternalServiceAlias" -> HttpURLConnection.HTTP_NOT_ACCEPTABLE
       "testFesServerEnterpriseServerAlias" -> HttpURLConnection.HTTP_CONFLICT
-      "testCallFesServerForEnterpriseUser" -> HttpURLConnection.HTTP_UNAUTHORIZED
+      "testCallFesUrlToGetClientConfigurationForEnterpriseUser" -> HttpURLConnection.HTTP_UNAUTHORIZED
       else -> HttpURLConnection.HTTP_OK
     }
 
@@ -493,7 +493,7 @@ class MainSignInFragmentEnterpriseFlowTest : BaseSignTest() {
       "testFesServerAvailableGetClientConfigurationFailed",
       "testFesServerExternalServiceAlias",
       "testFesServerEnterpriseServerAlias",
-      "testCallFesServerForEnterpriseUser" -> null
+      "testCallFesUrlToGetClientConfigurationForEnterpriseUser" -> null
       else -> gson.toJson(
         ClientConfigurationResponse(
           clientConfiguration = ClientConfiguration(

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseDraftsGmailAPIFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseDraftsGmailAPIFlowTest.kt
@@ -38,6 +38,7 @@ import com.flowcrypt.email.util.AccountDaoManager
 import com.flowcrypt.email.viewaction.CustomViewActions.clickOnFolderWithName
 import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.googleapis.json.GoogleJsonErrorContainer
+import com.google.api.client.json.Json
 import com.google.api.client.json.JsonObjectParser
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.gmail.model.Draft
@@ -274,6 +275,7 @@ abstract class BaseDraftsGmailAPIFlowTest : BaseTest() {
           return MockResponse().setResponseCode(HttpURLConnection.HTTP_NO_CONTENT)
         } else {
           return MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
+            .setHeader("Content-Type", Json.MEDIA_TYPE)
             .setBody(GoogleJsonErrorContainer().apply {
               factory = GsonFactory.getDefaultInstance()
               error = GoogleJsonError().apply {

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fes/login/MainSignInFragmentEnterpriseTestUseFesUrlFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fes/login/MainSignInFragmentEnterpriseTestUseFesUrlFlowTest.kt
@@ -1,0 +1,128 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: DenBond7
+ */
+
+package com.flowcrypt.email.ui.fes.login
+
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.flowcrypt.email.R
+import com.flowcrypt.email.TestConstants
+import com.flowcrypt.email.api.retrofit.ApiHelper
+import com.flowcrypt.email.api.retrofit.response.api.FesServerResponse
+import com.flowcrypt.email.api.retrofit.response.base.ApiError
+import com.flowcrypt.email.rules.ClearAppSettingsRule
+import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
+import com.flowcrypt.email.rules.GrantPermissionRuleChooser
+import com.flowcrypt.email.rules.RetryRule
+import com.flowcrypt.email.rules.ScreenshotTestRule
+import com.flowcrypt.email.ui.activity.MainActivity
+import com.flowcrypt.email.ui.base.BaseSignTest
+import com.flowcrypt.email.util.TestGeneralUtil
+import com.flowcrypt.email.util.exception.ApiException
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import java.net.HttpURLConnection
+
+/**
+ * @author Denis Bondarenko
+ *         Date: 10/31/19
+ *         Time: 3:08 PM
+ *         E-mail: DenBond7@gmail.com
+ */
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class MainSignInFragmentEnterpriseTestUseFesUrlFlowTest : BaseSignTest() {
+  override val useIntents: Boolean = true
+  override val activityScenarioRule = activityScenarioRule<MainActivity>(
+    TestGeneralUtil.genIntentForNavigationComponent(
+      destinationId = R.id.mainSignInFragment
+    )
+  )
+
+  private val mockWebServerRule =
+    FlowCryptMockWebServerRule(TestConstants.MOCK_WEB_SERVER_PORT, object : Dispatcher() {
+      override fun dispatch(request: RecordedRequest): MockResponse {
+        val gson = ApiHelper.getInstance(getTargetContext()).gson
+
+        when {
+          request.path.equals("/api/") -> {
+            return MockResponse().setResponseCode(HttpURLConnection.HTTP_OK)
+              .setBody(gson.toJson(FES_SUCCESS_RESPONSE))
+          }
+
+          request.path.equals("/api/v1/client-configuration?domain=localhost:1212") -> {
+            return handleClientConfigurationAPI()
+          }
+
+          request.path.equals("/account/get") -> {
+            isApiAccountUsed = true
+            return MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
+          }
+        }
+
+        return MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
+      }
+    })
+
+  @get:Rule
+  var ruleChain: TestRule = RuleChain
+    .outerRule(RetryRule.DEFAULT)
+    .around(ClearAppSettingsRule())
+    .around(GrantPermissionRuleChooser.grant(android.Manifest.permission.POST_NOTIFICATIONS))
+    .around(mockWebServerRule)
+    .around(activityScenarioRule)
+    .around(ScreenshotTestRule())
+
+  private var isFesUrlUsed = false
+  private var isApiAccountUsed = false
+
+  @Test
+  fun testCallFesUrlToGetClientConfigurationForEnterpriseUser() {
+    isFesUrlUsed = false
+    setupAndClickSignInButton(genMockGoogleSignInAccountJson(EMAIL_ENTERPRISE_USER))
+
+    assertEquals(false, isApiAccountUsed)
+    assertEquals(true, isFesUrlUsed)
+
+    //the mock web server should return error for https://fes.$domain/api/
+    isDialogWithTextDisplayed(
+      decorView,
+      "ApiException:" + ApiException(
+        ApiError(
+          code = HttpURLConnection.HTTP_UNAUTHORIZED,
+          msg = ""
+        )
+      ).message!!
+    )
+    //after this we will be sure that https://fes.$domain/api/ was called for an enterprise user
+  }
+
+  private fun handleClientConfigurationAPI(): MockResponse {
+    isFesUrlUsed = true
+    return MockResponse().setResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED)
+  }
+
+  companion object {
+    private const val EMAIL_ENTERPRISE_USER = "enterprise_user@localhost:1212"
+
+    private val FES_SUCCESS_RESPONSE = FesServerResponse(
+      apiError = null,
+      vendor = "FlowCrypt",
+      service = "external-service",
+      orgId = "localhost",
+      version = "2023-01",
+      endUserApiVersion = "v1",
+      adminApiVersion = "v1"
+    )
+  }
+}

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MainSignInFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MainSignInFragment.kt
@@ -739,11 +739,11 @@ class MainSignInFragment : BaseSingInFragment<FragmentMainSignInBinding>() {
   }
 
   private fun showDialogWithRetryButton(it: Result<ApiResponse>, requestCode: Int) {
-    showContent()
     showDialogWithRetryButton(it.exceptionMsg, requestCode)
   }
 
   private fun showDialogWithRetryButton(errorMsg: String, requestCode: Int) {
+    showContent()
     showTwoWayDialog(
       requestCode = requestCode,
       dialogTitle = "",


### PR DESCRIPTION
This PR added more tests for FES login

close #2147 

These changes include the following

1. Was added a case where we test that the app calls `FES` server if `FES URL` was provided. It resolves an issue discovered here https://github.com/FlowCrypt/flowcrypt-android/pull/2143#discussion_r1067109242
2. Was added a case where we test that the app uses a regular flow for public domains(`google.com`, `googlemail.com`)
3. I've relooked over the existing tests. They work well.
4. Code refactoring

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
