### PR TITLE
Improved PasswordProtectedAttachmentInfoDataSource

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/javamail/PasswordProtectedAttachmentInfoDataSource.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/javamail/PasswordProtectedAttachmentInfoDataSource.kt
@@ -11,12 +11,15 @@ import com.flowcrypt.email.security.pgp.PgpDecryptAndOrVerify
 import org.apache.commons.io.FilenameUtils
 import org.bouncycastle.openpgp.PGPSecretKeyRingCollection
 import org.pgpainless.key.protection.SecretKeyRingProtector
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
+import java.io.BufferedInputStream
 import java.io.InputStream
 
 /**
  * It's a special version of [AttachmentInfoDataSource] which decrypts a source before using.
+ * Due to https://github.com/pgpainless/pgpainless/pull/360 we have to use a custom implementation
+ * for streams here. For the first call of [jakarta.activation.DataSource.getInputStream]
+ * we will not care about errors for [InputStream.close].
+ *
  * Also, it drops a file extension(as this an incoming attachment here always will have '.pgp').
  *
  * @author Denys Bondarenko
@@ -27,18 +30,29 @@ class PasswordProtectedAttachmentInfoDataSource(
   private val secretKeys: PGPSecretKeyRingCollection,
   private val protector: SecretKeyRingProtector
 ) : AttachmentInfoDataSource(context, att) {
+  private var isFirstUsage = false
   override fun getInputStream(): InputStream? {
     val inputStream = super.getInputStream() ?: return null
-    val buffer = ByteArrayOutputStream()
     val decryptionStream = PgpDecryptAndOrVerify.genDecryptionStream(
       srcInputStream = inputStream,
       secretKeys = secretKeys,
       protector = protector
     )
-    decryptionStream.copyTo(buffer)
-    //ref https://github.com/pgpainless/pgpainless/pull/360
-    //todo-denbond7 should be improved to use a stream directly
-    return ByteArrayInputStream(buffer.toByteArray())
+
+    return if (isFirstUsage) {
+      decryptionStream
+    } else {
+      isFirstUsage = true
+      object : BufferedInputStream(decryptionStream) {
+        override fun close() {
+          try {
+            super.close()
+          } catch (e: Exception) {
+            //we don't care about exception here. Can be skipped.
+          }
+        }
+      }
+    }
   }
 
   override fun getName(): String {


### PR DESCRIPTION
This PR Improved PasswordProtectedAttachmentInfoDataSource to use a stream directly instead of reading all data to a buffer.

close #2202

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
