### PR TITLE
hide key ids when sending email with bcc recipients

### DIFF
--- a/FlowCrypt/build.gradle
+++ b/FlowCrypt/build.gradle
@@ -439,7 +439,8 @@ dependencies {
         exclude group: 'com.sun.mail'
     }
 
-    implementation('org.pgpainless:pgpainless-core:1.5.3')
+    implementation('org.pgpainless:pgpainless-core:1.5.4')
+
     implementation 'com.github.bumptech.glide:glide:4.15.1'
     implementation 'com.nulab-inc:zxcvbn:1.7.0'
     implementation 'commons-io:commons-io:2.13.0'

--- a/FlowCrypt/build.gradle
+++ b/FlowCrypt/build.gradle
@@ -451,7 +451,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.16.1'
     implementation 'com.sandinh:zbase32-commons-codec_2.12:1.0.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
-    implementation 'ch.acra:acra-http:5.9.7'
+    implementation 'ch.acra:acra-http:5.10.0'
     //ACRA needs the following dependency to use a custom report sender
     implementation 'com.google.auto.service:auto-service-annotations:1.1.0'
 

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/SendMsgTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/SendMsgTest.kt
@@ -494,9 +494,9 @@ class SendMsgTest {
             .asSequence()
             .toList()[1].keyID,
           0,
-        )
+        ).sortedArray()
 
-        val actualIds = messageMetadata.recipientKeyIds.toTypedArray()
+        val actualIds = messageMetadata.recipientKeyIds.toTypedArray().sortedArray()
 
         assertArrayEquals(
           "Expected = ${expectedIds.contentToString()}, actual = ${actualIds.contentToString()}",

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/SendMsgTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/SendMsgTest.kt
@@ -477,24 +477,31 @@ class SendMsgTest {
         assertEquals(true, messageMetadata.isEncrypted)
         assertEquals(true, messageMetadata.isSigned)
         assertEquals(outgoingMessageInfo.msg, String(buffer.toByteArray()))
+
+        val expectedIds = arrayOf(
+          PgpKey.parseKeys(recipientPgpKeyDetails.publicKey)
+            .pgpKeyRingCollection
+            .pgpPublicKeyRingCollection
+            .first()
+            .publicKeys
+            .asSequence()
+            .toList()[1].keyID,
+          PgpKey.parseKeys(addPrivateKeyToDatabaseRule.pgpKeyDetails.publicKey)
+            .pgpKeyRingCollection
+            .pgpPublicKeyRingCollection
+            .first()
+            .publicKeys
+            .asSequence()
+            .toList()[1].keyID,
+          0,
+        )
+
+        val actualIds = messageMetadata.recipientKeyIds.toTypedArray()
+
         assertArrayEquals(
-          arrayOf(
-            PgpKey.parseKeys(recipientPgpKeyDetails.publicKey)
-              .pgpKeyRingCollection
-              .pgpPublicKeyRingCollection
-              .first()
-              .publicKeys
-              .asSequence()
-              .toList()[1].keyID,
-            PgpKey.parseKeys(addPrivateKeyToDatabaseRule.pgpKeyDetails.publicKey)
-              .pgpKeyRingCollection
-              .pgpPublicKeyRingCollection
-              .first()
-              .publicKeys
-              .asSequence()
-              .toList()[1].keyID,
-            0,
-          ), messageMetadata.recipientKeyIds.toTypedArray()
+          "Expected = ${expectedIds.contentToString()}, actual = ${actualIds.contentToString()}",
+          expectedIds,
+          actualIds
         )
 
         assertFalse(

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/SendMsgTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/SendMsgTest.kt
@@ -57,6 +57,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
@@ -476,7 +477,37 @@ class SendMsgTest {
         assertEquals(true, messageMetadata.isEncrypted)
         assertEquals(true, messageMetadata.isSigned)
         assertEquals(outgoingMessageInfo.msg, String(buffer.toByteArray()))
-        assertEquals(outgoingMessageInfo.msg, messageMetadata.recipientKeyIds)
+        assertArrayEquals(
+          arrayOf(
+            PgpKey.parseKeys(recipientPgpKeyDetails.publicKey)
+              .pgpKeyRingCollection
+              .pgpPublicKeyRingCollection
+              .first()
+              .publicKeys
+              .asSequence()
+              .toList()[1].keyID,
+            PgpKey.parseKeys(addPrivateKeyToDatabaseRule.pgpKeyDetails.publicKey)
+              .pgpKeyRingCollection
+              .pgpPublicKeyRingCollection
+              .first()
+              .publicKeys
+              .asSequence()
+              .toList()[1].keyID,
+            0,
+          ), messageMetadata.recipientKeyIds.toTypedArray()
+        )
+
+        assertFalse(
+          messageMetadata.recipientKeyIds.contains(
+            PgpKey.parseKeys(bccPgpKeyDetails.publicKey)
+              .pgpKeyRingCollection
+              .pgpPublicKeyRingCollection
+              .first()
+              .publicKeys
+              .asSequence()
+              .toList()[1].keyID
+          )
+        )
       }
     }
   }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/EmailUtil.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/EmailUtil.kt
@@ -646,14 +646,24 @@ class EmailUtil {
       val session = Session.getInstance(Properties())
       val senderEmail = requireNotNull(outgoingMsgInfo.from?.address)
       var pubKeys: List<String>? = null
+      var protectedPubKeys: List<String>? = null
       var prvKeys: List<String>? = null
       var ringProtector: SecretKeyRingProtector? = null
 
       if (outgoingMsgInfo.encryptionType === MessageEncryptionType.ENCRYPTED) {
-        val recipients = outgoingMsgInfo.getAllRecipients().toMutableList()
+        val publicRecipients = outgoingMsgInfo.getPublicRecipients().toMutableList()
         pubKeys = mutableListOf()
-        pubKeys.addAll(SecurityUtils.getRecipientsUsablePubKeys(context, recipients))
+        pubKeys.addAll(SecurityUtils.getRecipientsUsablePubKeys(context, publicRecipients))
         pubKeys.addAll(SecurityUtils.getSenderPublicKeys(context, senderEmail))
+
+        val protectedRecipients = outgoingMsgInfo.getProtectedRecipients().toMutableList()
+        protectedPubKeys = mutableListOf()
+        protectedPubKeys.addAll(
+          SecurityUtils.getRecipientsUsablePubKeys(
+            context,
+            protectedRecipients
+          )
+        )
 
         if (signingRequired) {
           prvKeys = listOf(
@@ -672,6 +682,7 @@ class EmailUtil {
             session = session,
             info = outgoingMsgInfo,
             pubKeys = pubKeys,
+            protectedPubKeys = protectedPubKeys,
             prvKeys = prvKeys,
             protector = ringProtector,
             hideArmorMeta = hideArmorMeta
@@ -684,6 +695,7 @@ class EmailUtil {
             session = session,
             info = outgoingMsgInfo,
             pubKeys = pubKeys,
+            protectedPubKeys = protectedPubKeys,
             prvKeys = prvKeys,
             protector = ringProtector,
             hideArmorMeta = hideArmorMeta
@@ -989,6 +1001,7 @@ class EmailUtil {
       session: Session,
       info: OutgoingMessageInfo,
       pubKeys: List<String>? = null,
+      protectedPubKeys: List<String>? = null,
       prvKeys: List<String>? = null,
       protector: SecretKeyRingProtector? = null,
       hideArmorMeta: Boolean = false,
@@ -1004,6 +1017,7 @@ class EmailUtil {
           prepareBodyPart(
             info = info,
             pubKeys = pubKeys,
+            protectedPubKeys = protectedPubKeys,
             prvKeys = prvKeys,
             protector = protector,
             hideArmorMeta = hideArmorMeta
@@ -1017,6 +1031,7 @@ class EmailUtil {
       replyToMsg: MimeMessage,
       info: OutgoingMessageInfo,
       pubKeys: List<String>? = null,
+      protectedPubKeys: List<String>? = null,
       prvKeys: List<String>? = null,
       protector: SecretKeyRingProtector? = null,
       hideArmorMeta: Boolean = false,
@@ -1028,6 +1043,7 @@ class EmailUtil {
           prepareBodyPart(
             info = info,
             pubKeys = pubKeys,
+            protectedPubKeys = protectedPubKeys,
             prvKeys = prvKeys,
             protector = protector,
             hideArmorMeta = hideArmorMeta
@@ -1143,6 +1159,7 @@ class EmailUtil {
       session: Session,
       info: OutgoingMessageInfo,
       pubKeys: List<String>?,
+      protectedPubKeys: List<String>? = null,
       prvKeys: List<String>? = null,
       protector: SecretKeyRingProtector? = null,
       hideArmorMeta: Boolean = false,
@@ -1171,6 +1188,7 @@ class EmailUtil {
         replyToMsg = msg,
         info = info,
         pubKeys = pubKeys,
+        protectedPubKeys = protectedPubKeys,
         prvKeys = prvKeys,
         protector = protector,
         hideArmorMeta = hideArmorMeta
@@ -1180,6 +1198,7 @@ class EmailUtil {
     private fun prepareBodyPart(
       info: OutgoingMessageInfo,
       pubKeys: List<String>? = null,
+      protectedPubKeys: List<String>? = null,
       prvKeys: List<String>? = null,
       protector: SecretKeyRingProtector? = null,
       hideArmorMeta: Boolean = false,
@@ -1188,6 +1207,7 @@ class EmailUtil {
         val encryptedContent = PgpEncryptAndOrSign.encryptAndOrSignMsg(
           msg = info.msg ?: "",
           pubKeys = pubKeys ?: emptyList(),
+          protectedPubKeys = protectedPubKeys,
           prvKeys = prvKeys,
           secretKeyRingProtector = protector,
           hideArmorMeta = hideArmorMeta,

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/EmailUtil.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/EmailUtil.kt
@@ -652,18 +652,12 @@ class EmailUtil {
 
       if (outgoingMsgInfo.encryptionType === MessageEncryptionType.ENCRYPTED) {
         val publicRecipients = outgoingMsgInfo.getPublicRecipients().toMutableList()
-        pubKeys = mutableListOf()
-        pubKeys.addAll(SecurityUtils.getRecipientsUsablePubKeys(context, publicRecipients))
+        pubKeys =
+          SecurityUtils.getRecipientsUsablePubKeys(context, publicRecipients).toMutableList()
         pubKeys.addAll(SecurityUtils.getSenderPublicKeys(context, senderEmail))
 
         val protectedRecipients = outgoingMsgInfo.getProtectedRecipients().toMutableList()
-        protectedPubKeys = mutableListOf()
-        protectedPubKeys.addAll(
-          SecurityUtils.getRecipientsUsablePubKeys(
-            context,
-            protectedRecipients
-          )
-        )
+        protectedPubKeys = SecurityUtils.getRecipientsUsablePubKeys(context, protectedRecipients)
 
         if (signingRequired) {
           prvKeys = listOf(

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/model/OutgoingMessageInfo.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/model/OutgoingMessageInfo.kt
@@ -48,18 +48,10 @@ data class OutgoingMessageInfo constructor(
     return getPublicRecipients() + getProtectedRecipients()
   }
 
-  fun getPublicRecipients(): List<String> {
-    val publicRecipients = mutableListOf<String>()
-    toRecipients?.let { publicRecipients.addAll(it.map { address -> address.address }) }
-    ccRecipients?.let { publicRecipients.addAll(it.map { address -> address.address }) }
-    return publicRecipients
-  }
+  fun getPublicRecipients() =
+    ((toRecipients ?: emptyList()) + (ccRecipients ?: emptyList())).map { it.address }
 
-  fun getProtectedRecipients(): List<String> {
-    val protectedRecipients = mutableListOf<String>()
-    bccRecipients?.let { protectedRecipients.addAll(it.map { address -> address.address }) }
-    return protectedRecipients
-  }
+  fun getProtectedRecipients() = bccRecipients?.map { it.address } ?: emptyList()
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/model/OutgoingMessageInfo.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/model/OutgoingMessageInfo.kt
@@ -48,8 +48,11 @@ data class OutgoingMessageInfo constructor(
     return getPublicRecipients() + getProtectedRecipients()
   }
 
-  fun getPublicRecipients() =
-    ((toRecipients ?: emptyList()) + (ccRecipients ?: emptyList())).map { it.address }
+  fun getPublicRecipients(): List<String> {
+    val toAddresses = toRecipients?.map { it.address } ?: emptyList()
+    val ccAddresses = ccRecipients?.map { it.address } ?: emptyList()
+    return toAddresses + ccAddresses
+  }
 
   fun getProtectedRecipients() = bccRecipients?.map { it.address } ?: emptyList()
 

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/model/OutgoingMessageInfo.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/model/OutgoingMessageInfo.kt
@@ -56,9 +56,9 @@ data class OutgoingMessageInfo constructor(
   }
 
   fun getProtectedRecipients(): List<String> {
-    val allRecipients = mutableListOf<String>()
-    bccRecipients?.let { allRecipients.addAll(it.map { address -> address.address }) }
-    return allRecipients
+    val protectedRecipients = mutableListOf<String>()
+    bccRecipients?.let { protectedRecipients.addAll(it.map { address -> address.address }) }
+    return protectedRecipients
   }
 
   override fun equals(other: Any?): Boolean {

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/model/OutgoingMessageInfo.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/model/OutgoingMessageInfo.kt
@@ -45,9 +45,18 @@ data class OutgoingMessageInfo constructor(
    * @return A list of the all recipients
    */
   fun getAllRecipients(): List<String> {
+    return getPublicRecipients() + getProtectedRecipients()
+  }
+
+  fun getPublicRecipients(): List<String> {
+    val publicRecipients = mutableListOf<String>()
+    toRecipients?.let { publicRecipients.addAll(it.map { address -> address.address }) }
+    ccRecipients?.let { publicRecipients.addAll(it.map { address -> address.address }) }
+    return publicRecipients
+  }
+
+  fun getProtectedRecipients(): List<String> {
     val allRecipients = mutableListOf<String>()
-    toRecipients?.let { allRecipients.addAll(it.map { address -> address.address }) }
-    ccRecipients?.let { allRecipients.addAll(it.map { address -> address.address }) }
     bccRecipients?.let { allRecipients.addAll(it.map { address -> address.address }) }
     return allRecipients
   }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/extensions/kotlin/IterableExt.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/extensions/kotlin/IterableExt.kt
@@ -1,0 +1,24 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: denbond7
+ */
+
+package com.flowcrypt.email.extensions.kotlin
+
+import org.bouncycastle.bcpg.ArmoredInputStream
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+import org.pgpainless.PGPainless
+import java.io.ByteArrayInputStream
+
+/**
+ * @author Denys Bondarenko
+ */
+fun <T> Iterable<T>?.toPGPPublicKeyRingCollection(): PGPPublicKeyRingCollection? {
+  this ?: return null
+  val pubKeysStream = ByteArrayInputStream(this.joinToString(separator = "\n").toByteArray())
+  return pubKeysStream.use {
+    ArmoredInputStream(it).use { armoredInputStream ->
+      PGPainless.readKeyRing().publicKeyRingCollection(armoredInputStream)
+    }
+  }
+}

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/service/ProcessingOutgoingMessageInfoHelper.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/service/ProcessingOutgoingMessageInfoHelper.kt
@@ -299,12 +299,10 @@ object ProcessingOutgoingMessageInfoHelper {
                 encryptedTempFile.name
               )
             }
-            requireNotNull(pubKeys)
-
             PgpEncryptAndOrSign.encryptAndOrSign(
               srcInputStream = originalFileInputStream,
               destOutputStream = encryptedTempFile.outputStream(),
-              pubKeys = pubKeys,
+              pubKeys = requireNotNull(pubKeys),
               fileName = originalAttName,
             )
             uri = FileProvider.getUriForFile(


### PR DESCRIPTION
This PR fixed issue `hide key ids when sending email with bcc recipients`

close #2306

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
