### PR TITLE
Migrated to use FlowCryptTestSettings annotation instead of BaseActivityTestImplementation.useIntents for better flexibility.

### DIFF
--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/base/BaseActivityTestImplementation.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/base/BaseActivityTestImplementation.kt
@@ -21,7 +21,4 @@ interface BaseActivityTestImplementation {
 
   val activityScenario: ActivityScenario<*>?
     get() = activityScenarioRule?.scenario
-
-  val useIntents: Boolean
-    get() = false
 }

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/base/BaseTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/base/BaseTest.kt
@@ -79,6 +79,9 @@ abstract class BaseTest : BaseActivityTestImplementation {
   @get:Rule
   val flowCryptTestSettingsRule = FlowCryptTestSettingsRule()
 
+  private val useIntents
+    get() = flowCryptTestSettingsRule.flowCryptTestSettings?.useIntents ?: false
+
   protected val decorView: View?
     get() {
       var decorView: View? = null

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/junit/annotations/FlowCryptTestSettings.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/junit/annotations/FlowCryptTestSettings.kt
@@ -5,10 +5,13 @@
 
 package com.flowcrypt.email.junit.annotations
 
+import java.lang.annotation.Inherited
+
 /**
  * @author Denys Bondarenko
  */
 @Retention(AnnotationRetention.RUNTIME)
+@Inherited
 @Target(
   AnnotationTarget.FUNCTION,
   AnnotationTarget.PROPERTY_GETTER,
@@ -17,7 +20,12 @@ package com.flowcrypt.email.junit.annotations
 )
 annotation class FlowCryptTestSettings(
   /**
-   * Should we register the common idling.
+   * Subscribe to the common idling.
    */
-  val useCommonIdling: Boolean = true
+  val useCommonIdling: Boolean = true,
+
+  /**
+   * Enable validation and stabbing of intents sent out by the application under test.
+   */
+  val useIntents: Boolean = false
 )

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/AddNewAccountEnterpriseFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/AddNewAccountEnterpriseFlowTest.kt
@@ -18,6 +18,7 @@ import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.retrofit.ApiHelper
 import com.flowcrypt.email.api.retrofit.response.api.ClientConfigurationResponse
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
@@ -40,10 +41,10 @@ import java.net.HttpURLConnection
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class AddNewAccountEnterpriseFlowTest : BaseSignTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>()
 
   @get:Rule

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/DisallowUpdateRevokedKeyFromSettingsFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/DisallowUpdateRevokedKeyFromSettingsFlowTest.kt
@@ -16,6 +16,7 @@ import com.flowcrypt.email.R
 import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.entity.RecipientEntity
 import com.flowcrypt.email.database.entity.relation.RecipientWithPubKeys
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
 import com.flowcrypt.email.rules.AddRecipientsToDatabaseRule
@@ -39,10 +40,10 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class DisallowUpdateRevokedKeyFromSettingsFlowTest : BaseTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.parseAndSavePubKeysFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/EndPassPhraseSessionFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/EndPassPhraseSessionFlowTest.kt
@@ -27,6 +27,7 @@ import com.flowcrypt.email.R
 import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.entity.KeyEntity
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.model.KeyImportDetails
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -53,6 +54,7 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class EndPassPhraseSessionFlowTest : BaseTest() {
@@ -65,7 +67,6 @@ class EndPassPhraseSessionFlowTest : BaseTest() {
     passphraseType = KeyEntity.PassphraseType.RAM
   )
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.privateKeyDetailsFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportRecipientAllowAttesterSearchOnlyForDomainsEmptyFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportRecipientAllowAttesterSearchOnlyForDomainsEmptyFlowTest.kt
@@ -18,6 +18,7 @@ import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
@@ -35,6 +36,7 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class ImportRecipientAllowAttesterSearchOnlyForDomainsEmptyFlowTest : BaseTest() {
@@ -55,7 +57,6 @@ class ImportRecipientAllowAttesterSearchOnlyForDomainsEmptyFlowTest : BaseTest()
 
   private val addAccountToDatabaseRule = AddAccountToDatabaseRule(userWithClientConfiguration)
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.importRecipientsFromSourceFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportRecipientAllowAttesterSearchOnlyForDomainsFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportRecipientAllowAttesterSearchOnlyForDomainsFlowTest.kt
@@ -20,6 +20,7 @@ import com.flowcrypt.email.R
 import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
@@ -43,6 +44,7 @@ import java.net.HttpURLConnection
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class ImportRecipientAllowAttesterSearchOnlyForDomainsFlowTest : BaseTest() {
@@ -63,7 +65,6 @@ class ImportRecipientAllowAttesterSearchOnlyForDomainsFlowTest : BaseTest() {
 
   private val addAccountToDatabaseRule = AddAccountToDatabaseRule(userWithClientConfiguration)
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.importRecipientsFromSourceFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportRecipientDisallowAttesterSearchFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportRecipientDisallowAttesterSearchFlowTest.kt
@@ -19,6 +19,7 @@ import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
@@ -36,6 +37,7 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class ImportRecipientDisallowAttesterSearchFlowTest : BaseTest() {
@@ -55,7 +57,6 @@ class ImportRecipientDisallowAttesterSearchFlowTest : BaseTest() {
 
   private val addAccountToDatabaseRule = AddAccountToDatabaseRule(userWithClientConfiguration)
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.importRecipientsFromSourceFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportRecipientsFromSourceFragmentFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportRecipientsFromSourceFragmentFlowTest.kt
@@ -21,6 +21,7 @@ import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
@@ -46,12 +47,12 @@ import java.net.HttpURLConnection
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class ImportRecipientsFromSourceFragmentFlowTest : BaseTest() {
   private val addAccountToDatabaseRule = AddAccountToDatabaseRule()
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.importRecipientsFromSourceFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportUpdatedVersionOfPrivateKeyViaSettingsImportFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/ImportUpdatedVersionOfPrivateKeyViaSettingsImportFlowTest.kt
@@ -20,6 +20,7 @@ import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.hasItem
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withRecyclerViewItemCount
 import com.flowcrypt.email.model.KeyImportDetails
@@ -43,10 +44,10 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class ImportUpdatedVersionOfPrivateKeyViaSettingsImportFlowTest : BaseTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.privateKeysListFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/MainSignInFragmentFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/MainSignInFragmentFlowTest.kt
@@ -25,6 +25,7 @@ import com.flowcrypt.email.api.retrofit.response.api.FesServerResponse
 import com.flowcrypt.email.api.retrofit.response.base.ApiError
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.api.retrofit.response.model.Key
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.junit.annotations.NotReadyForCI
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
@@ -57,10 +58,10 @@ import java.net.HttpURLConnection
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class MainSignInFragmentFlowTest : BaseSignTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.mainSignInFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeyDetailsFragmentEkmFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeyDetailsFragmentEkmFlowTest.kt
@@ -17,6 +17,7 @@ import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.entity.KeyEntity
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.model.KeyImportDetails
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -39,6 +40,7 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PrivateKeyDetailsFragmentEkmFlowTest : BaseTest() {
@@ -64,7 +66,6 @@ class PrivateKeyDetailsFragmentEkmFlowTest : BaseTest() {
     passphraseType = KeyEntity.PassphraseType.RAM
   )
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.privateKeyDetailsFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeyDetailsFragmentFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeyDetailsFragmentFlowTest.kt
@@ -19,6 +19,7 @@ import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.entity.KeyEntity
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.model.KeyImportDetails
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -40,6 +41,7 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PrivateKeyDetailsFragmentFlowTest : BaseTest() {
@@ -65,7 +67,6 @@ class PrivateKeyDetailsFragmentFlowTest : BaseTest() {
     passphraseType = KeyEntity.PassphraseType.RAM
   )
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.privateKeyDetailsFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeyDetailsFragmentPassInRamFlexibleTimeFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeyDetailsFragmentPassInRamFlexibleTimeFlowTest.kt
@@ -23,6 +23,7 @@ import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.entity.KeyEntity
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.model.KeyImportDetails
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -45,6 +46,7 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PrivateKeyDetailsFragmentPassInRamFlexibleTimeFlowTest : BaseTest() {
@@ -71,7 +73,6 @@ class PrivateKeyDetailsFragmentPassInRamFlexibleTimeFlowTest : BaseTest() {
     passphraseType = KeyEntity.PassphraseType.RAM
   )
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.privateKeyDetailsFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeysListFragmentFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeysListFragmentFlowTest.kt
@@ -24,6 +24,7 @@ import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withRecyclerViewItemCount
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -46,10 +47,10 @@ import java.io.File
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PrivateKeysListFragmentFlowTest : BaseTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.privateKeysListFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PublicKeyDetailsFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PublicKeyDetailsFlowTest.kt
@@ -30,6 +30,7 @@ import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.FlowCryptRoomDatabase
 import com.flowcrypt.email.database.entity.RecipientEntity
 import com.flowcrypt.email.database.entity.relation.RecipientWithPubKeys
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddRecipientsToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
@@ -56,13 +57,13 @@ import java.util.Date
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PublicKeyDetailsFlowTest : BaseTest() {
   private val keyDetails =
     PrivateKeysManager.getPgpKeyDetailsFromAssets("pgp/expired@flowcrypt.test_pub.asc")
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.publicKeyDetailsFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PublicKeyDetailsHideArmorMetaFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PublicKeyDetailsHideArmorMetaFlowTest.kt
@@ -31,6 +31,7 @@ import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.entity.MessageEntity
 import com.flowcrypt.email.database.entity.RecipientEntity
 import com.flowcrypt.email.database.entity.relation.RecipientWithPubKeys
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddRecipientsToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
@@ -64,6 +65,7 @@ import java.util.Properties
 /**
  * https://github.com/FlowCrypt/flowcrypt-android/issues/1532
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PublicKeyDetailsHideArmorMetaFlowTest : BaseTest() {
@@ -84,7 +86,6 @@ class PublicKeyDetailsHideArmorMetaFlowTest : BaseTest() {
   private val publicKeyEntity =
     keyDetails.toPublicKeyEntity(addAccountToDatabaseRule.account.email).copy(id = 12)
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.publicKeyDetailsFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/RecipientsListFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/RecipientsListFlowTest.kt
@@ -22,6 +22,7 @@ import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withRecyclerViewItemCount
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -42,10 +43,10 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class RecipientsListFlowTest : BaseRecipientsListTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.recipientsListFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/SignInScreenFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/SignInScreenFlowTest.kt
@@ -19,6 +19,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
 import com.flowcrypt.email.rules.RetryRule
@@ -35,10 +36,10 @@ import org.junit.runner.RunWith
  *
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class SignInScreenFlowTest : BaseTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>()
 
   @get:Rule

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/StandardReplyWithServiceInfoAndOneFileFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/StandardReplyWithServiceInfoAndOneFileFlowTest.kt
@@ -27,6 +27,7 @@ import com.flowcrypt.email.api.email.model.AttachmentInfo
 import com.flowcrypt.email.api.email.model.IncomingMessageInfo
 import com.flowcrypt.email.api.email.model.ServiceInfo
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.junit.annotations.NotReadyForCI
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withChipCloseIconAvailability
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withRecyclerViewItemCount
@@ -55,6 +56,7 @@ import org.junit.runner.RunWith
  *
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class StandardReplyWithServiceInfoAndOneFileFlowTest : BaseTest() {
@@ -87,7 +89,6 @@ class StandardReplyWithServiceInfoAndOneFileFlowTest : BaseTest() {
     atts = listOf(attachmentInfo)
   )
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<CreateMessageActivity>(
     intent = CreateMessageActivity.generateIntent(
       getTargetContext(),

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/SubmitPublicKeyAfterCreationNonGoogleAccountFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/SubmitPublicKeyAfterCreationNonGoogleAccountFlowTest.kt
@@ -15,10 +15,13 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.email.IMAPStoreConnection
 import com.flowcrypt.email.junit.annotations.DependsOnMailServer
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
@@ -38,6 +41,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
+import org.junit.runner.RunWith
 import java.net.HttpURLConnection
 import java.util.UUID
 
@@ -46,9 +50,11 @@ import java.util.UUID
  *
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @DependsOnMailServer
+@MediumTest
+@RunWith(AndroidJUnit4::class)
 class SubmitPublicKeyAfterCreationNonGoogleAccountFlowTest : BaseSignTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>()
 
   private val userWithoutBackups = AccountDaoManager.getUserWithoutBackup()

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/SubmitPublicKeyToAttesterForImportedKeyDuringSetupFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/SubmitPublicKeyToAttesterForImportedKeyDuringSetupFlowTest.kt
@@ -25,6 +25,7 @@ import com.flowcrypt.email.api.retrofit.response.api.FesServerResponse
 import com.flowcrypt.email.api.retrofit.response.base.ApiError
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.extensions.org.bouncycastle.openpgp.toPgpKeyDetails
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
@@ -54,10 +55,10 @@ import java.net.HttpURLConnection
 /**
  * https://github.com/FlowCrypt/flowcrypt-android/issues/2014
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class SubmitPublicKeyToAttesterForImportedKeyDuringSetupFlowTest : BaseSignTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.mainSignInFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/UpdatePrivateKeyWithPassPhraseInDatabaseFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/UpdatePrivateKeyWithPassPhraseInDatabaseFlowTest.kt
@@ -23,6 +23,7 @@ import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.FlowCryptRoomDatabase
 import com.flowcrypt.email.database.entity.RecipientEntity
 import com.flowcrypt.email.database.entity.relation.RecipientWithPubKeys
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
 import com.flowcrypt.email.rules.AddRecipientsToDatabaseRule
@@ -51,6 +52,7 @@ import java.util.Date
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class UpdatePrivateKeyWithPassPhraseInDatabaseFlowTest : BaseTest() {
@@ -59,7 +61,6 @@ class UpdatePrivateKeyWithPassPhraseInDatabaseFlowTest : BaseTest() {
     keyPath = "pgp/default@flowcrypt.test_fisrtKey_prv_default_mod_06_17_2022.asc"
   )
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.privateKeyDetailsFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/UpdatePrivateKeyWithPassPhraseInRamFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/UpdatePrivateKeyWithPassPhraseInRamFlowTest.kt
@@ -29,6 +29,7 @@ import com.flowcrypt.email.database.entity.AccountSettingsEntity
 import com.flowcrypt.email.database.entity.KeyEntity
 import com.flowcrypt.email.database.entity.RecipientEntity
 import com.flowcrypt.email.database.entity.relation.RecipientWithPubKeys
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withTextInputLayoutError
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -56,6 +57,7 @@ import java.util.Date
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class UpdatePrivateKeyWithPassPhraseInRamFlowTest : BaseTest() {
@@ -64,7 +66,6 @@ class UpdatePrivateKeyWithPassPhraseInRamFlowTest : BaseTest() {
     passphraseType = KeyEntity.PassphraseType.RAM
   )
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.privateKeyDetailsFragment,

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseBackupKeysFragmentTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseBackupKeysFragmentTest.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasCategories
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasType
 import com.flowcrypt.email.Constants
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasItem
@@ -23,9 +24,8 @@ import java.io.File
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 abstract class BaseBackupKeysFragmentTest : BaseTest(), AddAccountToDatabaseRuleInterface {
-  override val useIntents: Boolean = true
-
   protected fun intendingFileChoose(file: File) {
     val resultData = Intent()
     resultData.data = Uri.fromFile(file)

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseComposeScreenTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseComposeScreenTest.kt
@@ -23,6 +23,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.flowcrypt.email.R
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.model.MessageType
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.LazyActivityScenarioRule
@@ -36,8 +37,8 @@ import java.io.File
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 abstract class BaseComposeScreenTest : BaseTest() {
-  override val useIntents: Boolean = true
   override val activeActivityRule: LazyActivityScenarioRule<CreateMessageActivity>? =
     lazyActivityScenarioRule(launchActivity = false)
   override val activityScenario: ActivityScenario<*>?

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseFesDuringSetupFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseFesDuringSetupFlowTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.rules.activityScenarioRule
 import com.flowcrypt.email.R
 import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.retrofit.ApiHelper
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
 import com.flowcrypt.email.ui.activity.MainActivity
 import com.flowcrypt.email.util.TestGeneralUtil
@@ -21,8 +22,8 @@ import org.junit.rules.TestName
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 abstract class BaseFesDuringSetupFlowTest : BaseSignTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.mainSignInFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseMessageDetailsFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseMessageDetailsFlowTest.kt
@@ -37,6 +37,7 @@ import com.flowcrypt.email.api.retrofit.response.model.DecryptErrorMsgBlock
 import com.flowcrypt.email.api.retrofit.response.model.MsgBlock
 import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.entity.MessageEntity
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withDrawable
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withPgpBadge
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withRecyclerViewItemCount
@@ -62,8 +63,8 @@ import org.junit.After
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 abstract class BaseMessageDetailsFlowTest : BaseTest() {
-  override val useIntents: Boolean = true
   override val activeActivityRule =
     lazyActivityScenarioRule<MainActivity>(launchActivity = false)
   override val activityScenario: ActivityScenario<*>?

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fes/login/MainSignInFragmentEnterpriseTestUseFesUrlFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fes/login/MainSignInFragmentEnterpriseTestUseFesUrlFlowTest.kt
@@ -13,6 +13,7 @@ import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.retrofit.ApiHelper
 import com.flowcrypt.email.api.retrofit.response.api.FesServerResponse
 import com.flowcrypt.email.api.retrofit.response.base.ApiError
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
@@ -36,10 +37,10 @@ import java.net.HttpURLConnection
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class MainSignInFragmentEnterpriseTestUseFesUrlFlowTest : BaseSignTest() {
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.mainSignInFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/ImportRecipientsFromSourceFragmentDisallowAttesterSearchForDomainFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/ImportRecipientsFromSourceFragmentDisallowAttesterSearchForDomainFlowTest.kt
@@ -20,6 +20,7 @@ import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.api.retrofit.response.model.ClientConfiguration
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
@@ -37,6 +38,7 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class ImportRecipientsFromSourceFragmentDisallowAttesterSearchForDomainFlowTest : BaseTest() {
@@ -56,7 +58,6 @@ class ImportRecipientsFromSourceFragmentDisallowAttesterSearchForDomainFlowTest 
 
   private val addAccountToDatabaseRule = AddAccountToDatabaseRule(userWithClientConfiguration)
 
-  override val useIntents: Boolean = true
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.importRecipientsFromSourceFragment

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/AddOtherAccountFragmentInIsolationTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/AddOtherAccountFragmentInIsolationTest.kt
@@ -24,6 +24,7 @@ import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.api.email.JavaEmailConstants
 import com.flowcrypt.email.api.email.model.AuthCredentials
 import com.flowcrypt.email.api.email.model.SecurityType
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.matchers.CustomMatchers.Companion.withSecurityTypeOption
 import com.flowcrypt.email.rules.ClearAppSettingsRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
@@ -32,10 +33,10 @@ import com.flowcrypt.email.rules.ScreenshotTestRule
 import com.flowcrypt.email.ui.activity.fragment.AddOtherAccountFragment
 import com.flowcrypt.email.ui.base.AddOtherAccountBaseTest
 import com.flowcrypt.email.util.AuthCredentialsManager
-import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.emptyString
 import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Rule
@@ -47,11 +48,10 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class AddOtherAccountFragmentInIsolationTest : AddOtherAccountBaseTest() {
-  override val useIntents: Boolean = true
-
   @get:Rule
   var ruleChain: TestRule = RuleChain
     .outerRule(RetryRule.DEFAULT)

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/ImportAdditionalPrivateKeysFragmentInIsolationTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/ImportAdditionalPrivateKeysFragmentInIsolationTest.kt
@@ -13,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
@@ -30,10 +31,10 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class ImportAdditionalPrivateKeysFragmentInIsolationTest : BaseTest() {
-  override val useIntents: Boolean = true
 
   @get:Rule
   var ruleChain: TestRule = RuleChain

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentExpiredKeyInIsolationTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentExpiredKeyInIsolationTest.kt
@@ -15,6 +15,7 @@ import com.flowcrypt.email.R
 import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.base.BaseTest
 import com.flowcrypt.email.database.entity.KeyEntity
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.model.KeyImportDetails
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -39,6 +40,7 @@ import java.util.Date
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PrivateKeyDetailsFragmentExpiredKeyInIsolationTest : BaseTest() {
@@ -51,7 +53,6 @@ class PrivateKeyDetailsFragmentExpiredKeyInIsolationTest : BaseTest() {
     passphraseType = KeyEntity.PassphraseType.RAM
   )
   private val dateFormat = DateTimeUtil.getPgpDateFormat(getTargetContext())
-  override val useIntents: Boolean = true
 
   @get:Rule
   var ruleChain: TestRule = RuleChain

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentInIsolationTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentInIsolationTest.kt
@@ -28,6 +28,7 @@ import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import com.flowcrypt.email.Constants
 import com.flowcrypt.email.R
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.junit.annotations.NotReadyForCI
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -55,13 +56,13 @@ import java.util.Date
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PrivateKeyDetailsFragmentInIsolationTest : BaseTest() {
   private val addAccountToDatabaseRule = AddAccountToDatabaseRule()
   private val addPrivateKeyToDatabaseRule = AddPrivateKeyToDatabaseRule()
   private val dateFormat = DateTimeUtil.getPgpDateFormat(getTargetContext())
-  override val useIntents: Boolean = true
 
   @get:Rule
   var ruleChain: TestRule = RuleChain

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentWrongPassphraseInIsolationTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentWrongPassphraseInIsolationTest.kt
@@ -14,6 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
 import com.flowcrypt.email.base.BaseTest
+import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
 import com.flowcrypt.email.model.KeyImportDetails
 import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.AddPrivateKeyToDatabaseRule
@@ -34,6 +35,7 @@ import org.junit.runner.RunWith
 /**
  * @author Denys Bondarenko
  */
+@FlowCryptTestSettings(useIntents = true)
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class PrivateKeyDetailsFragmentWrongPassphraseInIsolationTest : BaseTest() {
@@ -44,7 +46,6 @@ class PrivateKeyDetailsFragmentWrongPassphraseInIsolationTest : BaseTest() {
     passphrase = "wrong passphrase",
     sourceType = KeyImportDetails.SourceType.EMAIL
   )
-  override val useIntents: Boolean = true
 
   @get:Rule
   var ruleChain: TestRule = RuleChain


### PR DESCRIPTION
This PR Migrated to use FlowCryptTestSettings annotation instead of BaseActivityTestImplementation.useIntents for better flexibility.

close #2484

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
