### PR TITLE
Improved the private key details screen UI

### DIFF
--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/UpdatePrivateKeyWithPassPhraseInDatabaseFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/UpdatePrivateKeyWithPassPhraseInDatabaseFlowTest.kt
@@ -109,7 +109,7 @@ class UpdatePrivateKeyWithPassPhraseInDatabaseFlowTest : BaseTest() {
     onView(
       withText(
         getResString(
-          R.string.template_modification_date,
+          R.string.template_modified,
           dateFormat.format(Date(requireNotNull(originalKeyDetails.lastModified)))
         )
       )
@@ -145,7 +145,7 @@ class UpdatePrivateKeyWithPassPhraseInDatabaseFlowTest : BaseTest() {
     onView(
       withText(
         getResString(
-          R.string.template_modification_date,
+          R.string.template_modified,
           dateFormat.format(Date(requireNotNull(updatedKeyDetails.lastModified)))
         )
       )

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/UpdatePrivateKeyWithPassPhraseInRamFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/UpdatePrivateKeyWithPassPhraseInRamFlowTest.kt
@@ -114,7 +114,7 @@ class UpdatePrivateKeyWithPassPhraseInRamFlowTest : BaseTest() {
     onView(
       withText(
         getResString(
-          R.string.template_modification_date,
+          R.string.template_modified,
           dateFormat.format(Date(requireNotNull(originalKeyDetails.lastModified)))
         )
       )
@@ -186,7 +186,7 @@ class UpdatePrivateKeyWithPassPhraseInRamFlowTest : BaseTest() {
     onView(
       withText(
         getResString(
-          R.string.template_modification_date,
+          R.string.template_modified,
           dateFormat.format(Date(requireNotNull(updatedKeyDetails.lastModified)))
         )
       )

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentExpiredKeyInIsolationTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentExpiredKeyInIsolationTest.kt
@@ -87,7 +87,7 @@ class PrivateKeyDetailsFragmentExpiredKeyInIsolationTest : BaseTest() {
         matches(
           withText(
             getHtmlString(
-              getResString(R.string.key_expiration, actualExpirationDate)
+              getResString(R.string.expires, actualExpirationDate)
             )
           )
         )

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentInIsolationTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/isolation/incontainer/PrivateKeyDetailsFragmentInIsolationTest.kt
@@ -9,12 +9,13 @@ import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
 import android.os.Environment
-import android.text.TextUtils
 import androidx.core.content.FileProvider
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasCategories
@@ -87,7 +88,7 @@ class PrivateKeyDetailsFragmentInIsolationTest : BaseTest() {
   fun testKeyDetailsCheckDetails() {
     val details = addPrivateKeyToDatabaseRule.pgpKeyRingDetails
 
-    onView(withId(R.id.tVFingerprint))
+    onView(withId(R.id.textViewFingerprint))
       .check(
         matches(
           withText(
@@ -107,7 +108,7 @@ class PrivateKeyDetailsFragmentInIsolationTest : BaseTest() {
           withText(
             getHtmlString(
               getResString(
-                R.string.template_creation_date,
+                R.string.template_created,
                 dateFormat.format(Date(details.created))
               )
             )
@@ -120,7 +121,7 @@ class PrivateKeyDetailsFragmentInIsolationTest : BaseTest() {
         matches(
           withText(
             getHtmlString(
-              getResString(R.string.key_expiration, getResString(R.string.key_does_not_expire))
+              getResString(R.string.expires, getResString(R.string.never))
             )
           )
         )
@@ -129,17 +130,14 @@ class PrivateKeyDetailsFragmentInIsolationTest : BaseTest() {
     onView(withId(R.id.tVPassPhraseVerification))
       .check(matches(withText(getResString(R.string.stored_pass_phrase_matched))))
 
-    onView(withId(R.id.tVUsers))
-      .check(
-        matches(
-          withText(
-            getResString(
-              R.string.template_users,
-              TextUtils.join(", ", details.mimeAddresses.map { it.address })
-            )
+    details.users.forEachIndexed { index, userId ->
+      onView(withId(R.id.recyclerViewUserIds))
+        .perform(
+          RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+            withText(getResString(R.string.template_user, index + 1, userId))
           )
         )
-      )
+    }
   }
 
   @Test

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PrivateKeyDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PrivateKeyDetailsFragment.kt
@@ -201,9 +201,11 @@ class PrivateKeyDetailsFragment : BaseFragment<FragmentPrivateKeyDetailsBinding>
     }
 
     binding?.btnShowPubKey?.setOnClickListener {
-      showInfoDialog(
-        dialogTitle = "",
-        dialogMsg = privateKeyDetailsViewModel.getPgpKeyDetails()?.publicKey
+      navController?.navigate(
+        PrivateKeyDetailsFragmentDirections
+          .actionPrivateKeyDetailsFragmentToPrivateToPublicKeyDetailsFragment(
+            fingerprint = args.fingerprint
+          )
       )
     }
 

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PrivateKeyDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PrivateKeyDetailsFragment.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.flowcrypt.email.Constants
 import com.flowcrypt.email.R
 import com.flowcrypt.email.api.retrofit.response.base.Result
@@ -50,6 +51,8 @@ import com.flowcrypt.email.security.model.PgpKeyRingDetails
 import com.flowcrypt.email.ui.activity.fragment.base.BaseFragment
 import com.flowcrypt.email.ui.activity.fragment.base.ProgressBehaviour
 import com.flowcrypt.email.ui.activity.fragment.dialog.TwoWayDialogFragment
+import com.flowcrypt.email.ui.adapter.UserIdListAdapter
+import com.flowcrypt.email.ui.adapter.recyclerview.itemdecoration.MarginItemDecoration
 import com.flowcrypt.email.util.DateTimeUtil
 import com.flowcrypt.email.util.GeneralUtil
 import com.flowcrypt.email.util.UIUtil
@@ -93,6 +96,8 @@ class PrivateKeyDetailsFragment : BaseFragment<FragmentPrivateKeyDetailsBinding>
     registerForActivityResult(CreateCustomDocument(Constants.MIME_TYPE_PGP_KEY)) { uri: Uri? ->
       uri?.let { saveKey(it) }
     }
+
+  private val userIdsAdapter = UserIdListAdapter()
 
   override val progressView: View?
     get() = binding?.progress?.root
@@ -243,6 +248,20 @@ class PrivateKeyDetailsFragment : BaseFragment<FragmentPrivateKeyDetailsBinding>
         }
       }
     }
+
+    initUserIdsRecyclerView()
+  }
+
+  private fun initUserIdsRecyclerView() {
+    binding?.recyclerViewUserIds?.apply {
+      layoutManager = LinearLayoutManager(context)
+      addItemDecoration(
+        MarginItemDecoration(
+          marginTop = resources.getDimensionPixelSize(R.dimen.default_margin_small)
+        )
+      )
+      adapter = userIdsAdapter
+    }
   }
 
   private fun showNeedPassphraseDialog() {
@@ -254,34 +273,71 @@ class PrivateKeyDetailsFragment : BaseFragment<FragmentPrivateKeyDetailsBinding>
   }
 
   private fun updateViews() {
-    privateKeyDetailsViewModel.getPgpKeyDetails()?.let { value ->
+    privateKeyDetailsViewModel.getPgpKeyDetails()?.let { pgpKeyRingDetails ->
+      val dateFormat = DateTimeUtil.getPgpDateFormat(context)
+
       UIUtil.setHtmlTextToTextView(
         getString(
           R.string.template_fingerprint,
-          GeneralUtil.doSectionsInText(" ", value.fingerprint, 4)
-        ), binding?.tVFingerprint
+          GeneralUtil.doSectionsInText(" ", pgpKeyRingDetails.fingerprint, 4)
+        ), binding?.textViewFingerprint
       )
 
-      binding?.textViewStatusValue?.backgroundTintList =
-        value.getColorStateListDependsOnStatus(requireContext())
-      binding?.textViewStatusValue?.setCompoundDrawablesWithIntrinsicBounds(
-        value.getStatusIconResId(), 0, 0, 0
-      )
-      binding?.textViewStatusValue?.text = value.getStatusText(requireContext())
+      binding?.textViewPrimaryKeyAlgorithm?.apply {
+        val bitStrength =
+          if (pgpKeyRingDetails.algo.bits != -1) pgpKeyRingDetails.algo.bits else null
+        val algoWithBits = pgpKeyRingDetails.algo.algorithm + (bitStrength?.let { "/$it" } ?: "")
+        text = context.getString(R.string.algorithm, algoWithBits)
+      }
 
-      val dateFormat = DateTimeUtil.getPgpDateFormat(context)
       binding?.textViewCreationDate?.text = getString(
-        R.string.template_creation_date,
-        dateFormat.format(Date(value.created))
+        R.string.template_created,
+        dateFormat.format(Date(pgpKeyRingDetails.created))
       )
-      binding?.textViewModificationDate?.text = getString(
-        R.string.template_modification_date,
-        dateFormat.format(Date(value.lastModified))
-      )
-      binding?.textViewExpirationDate?.text = value.expiration?.let {
-        getString(R.string.key_expiration, dateFormat.format(Date(it)))
-      } ?: getString(R.string.key_expiration, getString(R.string.key_does_not_expire))
-      binding?.tVUsers?.text = getString(R.string.template_users, value.getUserIdsAsSingleString())
+
+      binding?.textViewModificationDate?.text =
+        getString(R.string.template_modified, dateFormat.format(pgpKeyRingDetails.lastModified))
+
+
+      binding?.textViewExpirationDate?.apply {
+        text = pgpKeyRingDetails.expiration?.let {
+          getString(R.string.expires, dateFormat.format(Date(it)))
+        } ?: getString(R.string.expires, getString(R.string.never))
+      }
+
+      binding?.textViewUsableForEncryption?.apply {
+        text = context.getString(
+          R.string.usable_for_encryption, pgpKeyRingDetails.usableForEncryption.toString()
+        )
+
+        setTextColor(
+          UIUtil.getColor(
+            requireContext(),
+            if (pgpKeyRingDetails.usableForEncryption) R.color.colorPrimary else R.color.red
+          )
+        )
+      }
+
+      binding?.textViewUsableForSigning?.apply {
+        text = context.getString(
+          R.string.usable_for_signing, pgpKeyRingDetails.usableForSigning.toString()
+        )
+
+        setTextColor(
+          UIUtil.getColor(
+            requireContext(),
+            if (pgpKeyRingDetails.usableForSigning) R.color.colorAccent else R.color.red
+          )
+        )
+      }
+
+      binding?.textViewStatusValue?.apply {
+        backgroundTintList = pgpKeyRingDetails.getColorStateListDependsOnStatus(requireContext())
+        setCompoundDrawablesWithIntrinsicBounds(pgpKeyRingDetails.getStatusIconResId(), 0, 0, 0)
+        text = pgpKeyRingDetails.getStatusText(requireContext())
+      }
+
+      userIdsAdapter.submitList(pgpKeyRingDetails.users)
 
       val passPhrase = privateKeyDetailsViewModel.getPassphrase()
       val passPhraseType = privateKeyDetailsViewModel.getPassphraseType()

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PrivateToPublicKeyDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PrivateToPublicKeyDetailsFragment.kt
@@ -1,0 +1,71 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: denbond7
+ */
+
+package com.flowcrypt.email.ui.activity.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asFlow
+import androidx.navigation.fragment.navArgs
+import com.flowcrypt.email.databinding.FragmentPublicKeyDetailsBinding
+import com.flowcrypt.email.extensions.launchAndRepeatWithViewLifecycle
+import com.flowcrypt.email.extensions.navController
+import com.flowcrypt.email.extensions.org.bouncycastle.openpgp.armor
+import com.flowcrypt.email.jetpack.lifecycle.CustomAndroidViewModelFactory
+import com.flowcrypt.email.jetpack.viewmodel.PrivateKeyDetailsViewModel
+import com.flowcrypt.email.ui.activity.fragment.base.BasePublicKeyDetailsFragment
+import com.flowcrypt.email.ui.activity.fragment.base.ProgressBehaviour
+
+/**
+ * @author Denys Bondarenko
+ */
+class PrivateToPublicKeyDetailsFragment :
+  BasePublicKeyDetailsFragment<FragmentPublicKeyDetailsBinding>(), ProgressBehaviour {
+  override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
+    FragmentPublicKeyDetailsBinding.inflate(inflater, container, false)
+
+  private val args by navArgs<PrivateToPublicKeyDetailsFragmentArgs>()
+  private val privateKeyDetailsViewModel: PrivateKeyDetailsViewModel by viewModels {
+    object : CustomAndroidViewModelFactory(requireActivity().application) {
+      @Suppress("UNCHECKED_CAST")
+      override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return PrivateKeyDetailsViewModel(args.fingerprint, requireActivity().application) as T
+      }
+    }
+  }
+
+  override val publicKeyFingerprint: String
+    get() = args.fingerprint
+  override val keyOwnerEmail: String
+    get() = account?.email ?: ""
+  override val isAdditionActionsEnabled: Boolean = false
+
+  override val armoredPublicKey: String?
+    get() = privateKeyDetailsViewModel.publicKeyKeyRingInfoLiveData.value?.keys?.armor(
+      hideArmorMeta = account?.clientConfiguration?.shouldHideArmorMeta() ?: false
+    )
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    setupPrivateKeyDetailsViewModel()
+  }
+
+  private fun setupPrivateKeyDetailsViewModel() {
+    launchAndRepeatWithViewLifecycle {
+      privateKeyDetailsViewModel.publicKeyKeyRingInfoLiveData.asFlow().collect { keyRingInfo ->
+        if (keyRingInfo == null) {
+          navController?.navigateUp()
+        } else {
+          updateViews(keyRingInfo)
+          showContent()
+        }
+      }
+    }
+  }
+}

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PublicKeyDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PublicKeyDetailsFragment.kt
@@ -68,13 +68,6 @@ class PublicKeyDetailsFragment : BasePublicKeyDetailsFragment<FragmentPublicKeyD
       hideArmorMeta = account?.clientConfiguration?.shouldHideArmorMeta() ?: false
     )
 
-  override val progressView: View?
-    get() = binding?.progress?.root
-  override val contentView: View?
-    get() = binding?.layoutContent
-  override val statusView: View?
-    get() = binding?.status?.root
-
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     setupPublicKeyDetailsViewModel()

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PublicKeyDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/PublicKeyDetailsFragment.kt
@@ -5,30 +5,15 @@
 
 package com.flowcrypt.email.ui.activity.fragment
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import android.provider.DocumentsContract
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.result.contract.ActivityResultContracts.CreateDocument
-import androidx.core.view.MenuHost
-import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
-import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.LinearLayoutManager
-import com.flowcrypt.email.Constants
 import com.flowcrypt.email.R
 import com.flowcrypt.email.api.retrofit.response.base.Result
 import com.flowcrypt.email.database.FlowCryptRoomDatabase
@@ -40,39 +25,20 @@ import com.flowcrypt.email.extensions.incrementSafely
 import com.flowcrypt.email.extensions.launchAndRepeatWithViewLifecycle
 import com.flowcrypt.email.extensions.navController
 import com.flowcrypt.email.extensions.org.bouncycastle.openpgp.armor
-import com.flowcrypt.email.extensions.org.bouncycastle.openpgp.getLastModificationDate
-import com.flowcrypt.email.extensions.org.pgpainless.key.info.generateKeyCapabilitiesDrawable
-import com.flowcrypt.email.extensions.org.pgpainless.key.info.getColorStateListDependsOnStatus
-import com.flowcrypt.email.extensions.org.pgpainless.key.info.getPrimaryKey
-import com.flowcrypt.email.extensions.org.pgpainless.key.info.getStatusIcon
-import com.flowcrypt.email.extensions.org.pgpainless.key.info.getStatusText
 import com.flowcrypt.email.extensions.showInfoDialog
-import com.flowcrypt.email.extensions.toast
 import com.flowcrypt.email.jetpack.lifecycle.CustomAndroidViewModelFactory
 import com.flowcrypt.email.jetpack.viewmodel.PublicKeyDetailsViewModel
-import com.flowcrypt.email.ui.activity.fragment.base.BaseFragment
+import com.flowcrypt.email.ui.activity.fragment.base.BasePublicKeyDetailsFragment
 import com.flowcrypt.email.ui.activity.fragment.base.ProgressBehaviour
-import com.flowcrypt.email.ui.adapter.SubKeysListAdapter
-import com.flowcrypt.email.ui.adapter.UserIdListAdapter
-import com.flowcrypt.email.ui.adapter.recyclerview.itemdecoration.MarginItemDecoration
-import com.flowcrypt.email.util.DateTimeUtil
-import com.flowcrypt.email.util.GeneralUtil
-import com.flowcrypt.email.util.exception.ExceptionUtil
-import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
-import org.pgpainless.key.info.KeyRingInfo
-import java.io.FileNotFoundException
-import java.util.Date
-
 
 /**
  * This fragment shows the given public key details
  *
  * @author Denys Bondarenko
  */
-@ExperimentalCoroutinesApi
-class PublicKeyDetailsFragment : BaseFragment<FragmentPublicKeyDetailsBinding>(),
+class PublicKeyDetailsFragment : BasePublicKeyDetailsFragment<FragmentPublicKeyDetailsBinding>(),
   ProgressBehaviour {
   override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?) =
     FragmentPublicKeyDetailsBinding.inflate(inflater, container, false)
@@ -90,16 +56,17 @@ class PublicKeyDetailsFragment : BaseFragment<FragmentPublicKeyDetailsBinding>()
   private val cachedPublicKeyEntity: PublicKeyEntity?
     get() = publicKeyDetailsViewModel.publicKeyEntityStateFlow.value.data
 
-  private val armoredPublicKey: String?
+  override val publicKeyFingerprint: String
+    get() = args.publicKeyEntity.fingerprint
+  override val keyOwnerEmail: String
+    get() = args.recipientEntity.email
+  override val isAdditionActionsEnabled: Boolean = true
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  override val armoredPublicKey: String?
     get() = publicKeyDetailsViewModel.keyRingInfoStateFlow.value.data?.keys?.armor(
       hideArmorMeta = account?.clientConfiguration?.shouldHideArmorMeta() ?: false
     )
-
-  private val savePubKeyActivityResultLauncher =
-    registerForActivityResult(ExportPubKeyCreateDocument()) { uri: Uri? -> uri?.let { saveKey(it) } }
-
-  private val userIdsAdapter = UserIdListAdapter()
-  private val subKeysAdapter = SubKeysListAdapter()
 
   override val progressView: View?
     get() = binding?.progress?.root
@@ -110,63 +77,40 @@ class PublicKeyDetailsFragment : BaseFragment<FragmentPublicKeyDetailsBinding>()
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    initUserIdsRecyclerView()
-    initSubKeysRecyclerView()
     setupPublicKeyDetailsViewModel()
   }
 
-  override fun onSetupActionBarMenu(menuHost: MenuHost) {
-    super.onSetupActionBarMenu(menuHost)
-    menuHost.addMenuProvider(object : MenuProvider {
-      override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-        menuInflater.inflate(R.menu.fragment_pub_key_details, menu)
-      }
-
-      override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-        return when (menuItem.itemId) {
-          R.id.menuActionCopy -> {
-            val clipboard =
-              requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            clipboard.setPrimaryClip(ClipData.newPlainText("pubKey", armoredPublicKey))
-            toast(R.string.public_key_copied_to_clipboard)
-            true
-          }
-
-          R.id.menuActionSave -> {
-            chooseDest()
-            true
-          }
-
-          R.id.menuActionDelete -> {
-            lifecycleScope.launch {
-              val roomDatabase = FlowCryptRoomDatabase.getDatabase(requireContext())
-              roomDatabase.pubKeyDao().deleteSuspend(args.publicKeyEntity)
-              navController?.navigateUp()
-            }
-            true
-          }
-
-          R.id.menuActionEdit -> {
-            account?.let { accountEntity ->
-              cachedPublicKeyEntity?.let { publicKeyEntity ->
-                navController?.navigate(
-                  PublicKeyDetailsFragmentDirections
-                    .actionPublicKeyDetailsFragmentToEditContactFragment(
-                      accountEntity,
-                      publicKeyEntity
-                    )
-                )
-              }
-            }
-            true
-          }
-
-          else -> false
+  override fun handleAdditionMenuActions(menuItem: MenuItem): Boolean {
+    return when (menuItem.itemId) {
+      R.id.menuActionDelete -> {
+        lifecycleScope.launch {
+          val roomDatabase = FlowCryptRoomDatabase.getDatabase(requireContext())
+          roomDatabase.pubKeyDao().deleteSuspend(args.publicKeyEntity)
+          navController?.navigateUp()
         }
+        true
       }
-    }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+
+      R.id.menuActionEdit -> {
+        account?.let { accountEntity ->
+          cachedPublicKeyEntity?.let { publicKeyEntity ->
+            navController?.navigate(
+              PublicKeyDetailsFragmentDirections
+                .actionPublicKeyDetailsFragmentToEditContactFragment(
+                  accountEntity,
+                  publicKeyEntity
+                )
+            )
+          }
+        }
+        true
+      }
+
+      else -> super.handleAdditionMenuActions(menuItem)
+    }
   }
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   private fun setupPublicKeyDetailsViewModel() {
     launchAndRepeatWithViewLifecycle {
       publicKeyDetailsViewModel.publicKeyEntityStateFlow.collect { }
@@ -207,143 +151,10 @@ class PublicKeyDetailsFragment : BaseFragment<FragmentPublicKeyDetailsBinding>()
             showInfoDialog(dialogTitle = "", dialogMsg = msg)
             countingIdlingResource?.decrementSafely(this@PublicKeyDetailsFragment)
           }
+
           else -> {}
         }
       }
-    }
-  }
-
-  private fun saveKey(uri: Uri?) {
-    uri ?: return
-    try {
-      val context = this.context ?: return
-      val pubKey = armoredPublicKey ?: return
-      GeneralUtil.writeFileFromStringToUri(context, uri, pubKey)
-      toast(getString(R.string.saved))
-    } catch (e: Exception) {
-      e.printStackTrace()
-      var error = if (e.message.isNullOrEmpty()) e.javaClass.simpleName else e.message
-
-      if (e is IllegalStateException) {
-        if (e.message != null && e.message!!.startsWith("Already exists")) {
-          error = getString(R.string.not_saved_file_already_exists)
-          showInfoSnackbar(requireView(), error, Snackbar.LENGTH_LONG)
-
-          try {
-            context?.contentResolver?.let { contentResolver ->
-              DocumentsContract.deleteDocument(contentResolver, uri)
-            }
-          } catch (fileNotFound: FileNotFoundException) {
-            fileNotFound.printStackTrace()
-          }
-
-          return
-        } else {
-          ExceptionUtil.handleError(e)
-        }
-      } else {
-        ExceptionUtil.handleError(e)
-      }
-
-      showInfoSnackbar(requireView(), error ?: "")
-    }
-  }
-
-  private fun updateViews(keyRingInfo: KeyRingInfo) {
-    updatePrimaryKeyInfo(keyRingInfo)
-
-    userIdsAdapter.submitList(keyRingInfo.userIds)
-    subKeysAdapter.submit(keyRingInfo)
-  }
-
-  private fun updatePrimaryKeyInfo(keyRingInfo: KeyRingInfo) {
-    val dateFormat = DateTimeUtil.getPgpDateFormat(context)
-    binding?.textViewPrimaryKeyFingerprint?.text = GeneralUtil.doSectionsInText(
-      originalString = keyRingInfo.fingerprint.toString(), groupSize = 4
-    )
-
-    binding?.textViewPrimaryKeyAlgorithm?.apply {
-      val bitStrength =
-        if (keyRingInfo.publicKey.bitStrength != -1) keyRingInfo.publicKey.bitStrength else null
-      val algoWithBits = keyRingInfo.algorithm.name + (bitStrength?.let { "/$it" } ?: "")
-      text = algoWithBits
-    }
-
-    binding?.textViewPrimaryKeyCreated?.text = getString(
-      R.string.template_created,
-      dateFormat.format(Date(keyRingInfo.creationDate.time))
-    )
-
-    binding?.textViewPrimaryKeyModified?.apply {
-      text = keyRingInfo.getPrimaryKey()?.getLastModificationDate()?.let {
-        getString(R.string.template_modified, dateFormat.format(it))
-      }
-    }
-
-    binding?.textViewPrimaryKeyExpiration?.apply {
-      text = keyRingInfo.primaryKeyExpirationDate?.time?.let {
-        getString(R.string.expires, dateFormat.format(Date(it)))
-      } ?: getString(R.string.expires, getString(R.string.never))
-    }
-
-    binding?.textViewPrimaryKeyCapabilities?.setCompoundDrawablesWithIntrinsicBounds(
-      null,
-      null,
-      keyRingInfo.generateKeyCapabilitiesDrawable(
-        requireContext(), keyRingInfo.getPrimaryKey()?.keyID ?: 0
-      ),
-      null
-    )
-
-    binding?.textViewStatusValue?.apply {
-      backgroundTintList = keyRingInfo.getColorStateListDependsOnStatus(requireContext())
-      setCompoundDrawablesWithIntrinsicBounds(keyRingInfo.getStatusIcon(), 0, 0, 0)
-      text = keyRingInfo.getStatusText(requireContext())
-    }
-  }
-
-  private fun initUserIdsRecyclerView() {
-    binding?.recyclerViewUserIds?.apply {
-      layoutManager = LinearLayoutManager(context)
-      addItemDecoration(
-        MarginItemDecoration(
-          marginTop = resources.getDimensionPixelSize(R.dimen.default_margin_small)
-        )
-      )
-      adapter = userIdsAdapter
-    }
-  }
-
-  private fun initSubKeysRecyclerView() {
-    binding?.recyclerViewSubKeys?.apply {
-      val linearLayoutManager = LinearLayoutManager(context)
-      val decoration = DividerItemDecoration(context, linearLayoutManager.orientation)
-      layoutManager = linearLayoutManager
-      addItemDecoration(decoration)
-      addItemDecoration(
-        MarginItemDecoration(
-          marginTop = resources.getDimensionPixelSize(R.dimen.default_margin_small),
-          marginBottom = resources.getDimensionPixelSize(R.dimen.default_margin_small),
-        )
-      )
-      adapter = subKeysAdapter
-    }
-  }
-
-  private fun chooseDest() {
-    val sanitizedEmail = args.recipientEntity.email.replace("[^a-z0-9]".toRegex(), "")
-    val fileName = "0x" + cachedPublicKeyEntity?.fingerprint + "-" +
-        sanitizedEmail + "-public_key" + ".asc"
-    savePubKeyActivityResultLauncher.launch(fileName)
-  }
-
-  inner class ExportPubKeyCreateDocument :
-    CreateDocument("todo/todo") {
-    override fun createIntent(context: Context, input: String): Intent {
-
-      return super.createIntent(context, input)
-        .addCategory(Intent.CATEGORY_OPENABLE)
-        .setType(Constants.MIME_TYPE_PGP_KEY)
     }
   }
 }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/base/BasePublicKeyDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/base/BasePublicKeyDetailsFragment.kt
@@ -47,12 +47,20 @@ import java.util.Date
 /**
  * @author Denys Bondarenko
  */
-abstract class BasePublicKeyDetailsFragment<T : ViewBinding> : BaseFragment<T>() {
+abstract class BasePublicKeyDetailsFragment<T : ViewBinding> : BaseFragment<T>(),
+  ProgressBehaviour {
 
   abstract val armoredPublicKey: String?
   abstract val publicKeyFingerprint: String
   abstract val keyOwnerEmail: String
   abstract val isAdditionActionsEnabled: Boolean
+
+  override val progressView: View?
+    get() = viewBinding?.progress?.root
+  override val contentView: View?
+    get() = viewBinding?.layoutContent
+  override val statusView: View?
+    get() = viewBinding?.status?.root
 
   private val userIdsAdapter = UserIdListAdapter()
   private val subKeysAdapter = SubKeysListAdapter()

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/base/BasePublicKeyDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/base/BasePublicKeyDetailsFragment.kt
@@ -1,0 +1,242 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: denbond7
+ */
+
+package com.flowcrypt.email.ui.activity.fragment.base
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.DocumentsContract
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
+import androidx.lifecycle.Lifecycle
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.viewbinding.ViewBinding
+import com.flowcrypt.email.Constants
+import com.flowcrypt.email.R
+import com.flowcrypt.email.databinding.FragmentPublicKeyDetailsBinding
+import com.flowcrypt.email.extensions.org.bouncycastle.openpgp.getLastModificationDate
+import com.flowcrypt.email.extensions.org.pgpainless.key.info.generateKeyCapabilitiesDrawable
+import com.flowcrypt.email.extensions.org.pgpainless.key.info.getColorStateListDependsOnStatus
+import com.flowcrypt.email.extensions.org.pgpainless.key.info.getPrimaryKey
+import com.flowcrypt.email.extensions.org.pgpainless.key.info.getStatusIcon
+import com.flowcrypt.email.extensions.org.pgpainless.key.info.getStatusText
+import com.flowcrypt.email.extensions.toast
+import com.flowcrypt.email.ui.adapter.SubKeysListAdapter
+import com.flowcrypt.email.ui.adapter.UserIdListAdapter
+import com.flowcrypt.email.ui.adapter.recyclerview.itemdecoration.MarginItemDecoration
+import com.flowcrypt.email.util.DateTimeUtil
+import com.flowcrypt.email.util.GeneralUtil
+import com.flowcrypt.email.util.exception.ExceptionUtil
+import com.google.android.material.snackbar.Snackbar
+import org.pgpainless.key.info.KeyRingInfo
+import java.io.FileNotFoundException
+import java.util.Date
+
+/**
+ * @author Denys Bondarenko
+ */
+abstract class BasePublicKeyDetailsFragment<T : ViewBinding> : BaseFragment<T>() {
+
+  abstract val armoredPublicKey: String?
+  abstract val publicKeyFingerprint: String
+  abstract val keyOwnerEmail: String
+  abstract val isAdditionActionsEnabled: Boolean
+
+  private val userIdsAdapter = UserIdListAdapter()
+  private val subKeysAdapter = SubKeysListAdapter()
+
+  private val viewBinding: FragmentPublicKeyDetailsBinding?
+    get() = binding as? FragmentPublicKeyDetailsBinding
+
+  private val savePubKeyActivityResultLauncher =
+    registerForActivityResult(ExportPubKeyCreateDocument()) { uri: Uri? -> uri?.let { saveKey(it) } }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    initUserIdsRecyclerView()
+    initSubKeysRecyclerView()
+  }
+
+  override fun onSetupActionBarMenu(menuHost: MenuHost) {
+    super.onSetupActionBarMenu(menuHost)
+    menuHost.addMenuProvider(object : MenuProvider {
+      override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.fragment_pub_key_details, menu)
+      }
+
+      override fun onPrepareMenu(menu: Menu) {
+        super.onPrepareMenu(menu)
+        if (isAdditionActionsEnabled) {
+          menu.findItem(R.id.menuActionDelete)?.isVisible = true
+          menu.findItem(R.id.menuActionEdit)?.isVisible = true
+        }
+      }
+
+      override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        return when (menuItem.itemId) {
+          R.id.menuActionCopy -> {
+            val clipboard =
+              requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(ClipData.newPlainText("pubKey", armoredPublicKey))
+            toast(R.string.public_key_copied_to_clipboard)
+            true
+          }
+
+          R.id.menuActionSave -> {
+            chooseDest()
+            true
+          }
+
+          else -> handleAdditionMenuActions(menuItem)
+        }
+      }
+    }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+  }
+
+  open fun handleAdditionMenuActions(menuItem: MenuItem): Boolean = false
+
+  protected fun updateViews(keyRingInfo: KeyRingInfo) {
+    updatePrimaryKeyInfo(keyRingInfo)
+
+    userIdsAdapter.submitList(keyRingInfo.userIds)
+    subKeysAdapter.submit(keyRingInfo)
+  }
+
+  private fun initUserIdsRecyclerView() {
+    viewBinding?.recyclerViewUserIds?.apply {
+      layoutManager = LinearLayoutManager(context)
+      addItemDecoration(
+        MarginItemDecoration(
+          marginTop = resources.getDimensionPixelSize(R.dimen.default_margin_small)
+        )
+      )
+      adapter = userIdsAdapter
+    }
+  }
+
+  private fun initSubKeysRecyclerView() {
+    viewBinding?.recyclerViewSubKeys?.apply {
+      val linearLayoutManager = LinearLayoutManager(context)
+      val decoration = DividerItemDecoration(context, linearLayoutManager.orientation)
+      layoutManager = linearLayoutManager
+      addItemDecoration(decoration)
+      addItemDecoration(
+        MarginItemDecoration(
+          marginTop = resources.getDimensionPixelSize(R.dimen.default_margin_small),
+          marginBottom = resources.getDimensionPixelSize(R.dimen.default_margin_small),
+        )
+      )
+      adapter = subKeysAdapter
+    }
+  }
+
+  private fun saveKey(uri: Uri?) {
+    uri ?: return
+    try {
+      val context = this.context ?: return
+      val pubKey = armoredPublicKey ?: return
+      GeneralUtil.writeFileFromStringToUri(context, uri, pubKey)
+      toast(getString(R.string.saved))
+    } catch (e: Exception) {
+      e.printStackTrace()
+      var error = if (e.message.isNullOrEmpty()) e.javaClass.simpleName else e.message
+
+      if (e is IllegalStateException) {
+        if (e.message != null && e.message!!.startsWith("Already exists")) {
+          error = getString(R.string.not_saved_file_already_exists)
+          showInfoSnackbar(requireView(), error, Snackbar.LENGTH_LONG)
+
+          try {
+            context?.contentResolver?.let { contentResolver ->
+              DocumentsContract.deleteDocument(contentResolver, uri)
+            }
+          } catch (fileNotFound: FileNotFoundException) {
+            fileNotFound.printStackTrace()
+          }
+
+          return
+        } else {
+          ExceptionUtil.handleError(e)
+        }
+      } else {
+        ExceptionUtil.handleError(e)
+      }
+
+      showInfoSnackbar(requireView(), error ?: "")
+    }
+  }
+
+  private fun updatePrimaryKeyInfo(keyRingInfo: KeyRingInfo) {
+    val dateFormat = DateTimeUtil.getPgpDateFormat(context)
+    viewBinding?.textViewPrimaryKeyFingerprint?.text = GeneralUtil.doSectionsInText(
+      originalString = keyRingInfo.fingerprint.toString(), groupSize = 4
+    )
+
+    viewBinding?.textViewPrimaryKeyAlgorithm?.apply {
+      val bitStrength =
+        if (keyRingInfo.publicKey.bitStrength != -1) keyRingInfo.publicKey.bitStrength else null
+      val algoWithBits = keyRingInfo.algorithm.name + (bitStrength?.let { "/$it" } ?: "")
+      text = algoWithBits
+    }
+
+    viewBinding?.textViewPrimaryKeyCreated?.text = getString(
+      R.string.template_created,
+      dateFormat.format(Date(keyRingInfo.creationDate.time))
+    )
+
+    viewBinding?.textViewPrimaryKeyModified?.apply {
+      text = keyRingInfo.getPrimaryKey()?.getLastModificationDate()?.let {
+        getString(R.string.template_modified, dateFormat.format(it))
+      }
+    }
+
+    viewBinding?.textViewPrimaryKeyExpiration?.apply {
+      text = keyRingInfo.primaryKeyExpirationDate?.time?.let {
+        getString(R.string.expires, dateFormat.format(Date(it)))
+      } ?: getString(R.string.expires, getString(R.string.never))
+    }
+
+    viewBinding?.textViewPrimaryKeyCapabilities?.setCompoundDrawablesWithIntrinsicBounds(
+      null,
+      null,
+      keyRingInfo.generateKeyCapabilitiesDrawable(
+        requireContext(), keyRingInfo.getPrimaryKey()?.keyID ?: 0
+      ),
+      null
+    )
+
+    viewBinding?.textViewStatusValue?.apply {
+      backgroundTintList = keyRingInfo.getColorStateListDependsOnStatus(requireContext())
+      setCompoundDrawablesWithIntrinsicBounds(keyRingInfo.getStatusIcon(), 0, 0, 0)
+      text = keyRingInfo.getStatusText(requireContext())
+    }
+  }
+
+  private fun chooseDest() {
+    val sanitizedEmail = keyOwnerEmail.replace("[^a-z0-9]".toRegex(), "")
+    val fileName = "0x$publicKeyFingerprint-$sanitizedEmail-public_key.asc"
+    savePubKeyActivityResultLauncher.launch(fileName)
+  }
+
+  inner class ExportPubKeyCreateDocument :
+    ActivityResultContracts.CreateDocument("todo/todo") {
+    override fun createIntent(context: Context, input: String): Intent {
+
+      return super.createIntent(context, input)
+        .addCategory(Intent.CATEGORY_OPENABLE)
+        .setType(Constants.MIME_TYPE_PGP_KEY)
+    }
+  }
+}

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/base/BasePublicKeyDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/base/BasePublicKeyDetailsFragment.kt
@@ -32,6 +32,7 @@ import com.flowcrypt.email.extensions.org.pgpainless.key.info.getColorStateListD
 import com.flowcrypt.email.extensions.org.pgpainless.key.info.getPrimaryKey
 import com.flowcrypt.email.extensions.org.pgpainless.key.info.getStatusIcon
 import com.flowcrypt.email.extensions.org.pgpainless.key.info.getStatusText
+import com.flowcrypt.email.extensions.showInfoDialog
 import com.flowcrypt.email.extensions.toast
 import com.flowcrypt.email.ui.adapter.SubKeysListAdapter
 import com.flowcrypt.email.ui.adapter.UserIdListAdapter
@@ -104,6 +105,11 @@ abstract class BasePublicKeyDetailsFragment<T : ViewBinding> : BaseFragment<T>()
 
           R.id.menuActionSave -> {
             chooseDest()
+            true
+          }
+
+          R.id.menuActionShow -> {
+            showInfoDialog(dialogTitle = "", dialogMsg = armoredPublicKey)
             true
           }
 

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/adapter/RecipientsRecyclerViewAdapter.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/adapter/RecipientsRecyclerViewAdapter.kt
@@ -8,15 +8,14 @@ package com.flowcrypt.email.ui.adapter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.flowcrypt.email.R
 import com.flowcrypt.email.database.entity.RecipientEntity
+import com.flowcrypt.email.databinding.ContactItemBinding
 import com.flowcrypt.email.extensions.gone
+import com.flowcrypt.email.extensions.invisible
 import com.flowcrypt.email.extensions.visible
 import com.flowcrypt.email.extensions.visibleOrGone
 
@@ -28,15 +27,13 @@ import com.flowcrypt.email.extensions.visibleOrGone
 class RecipientsRecyclerViewAdapter(
   val isDeleteEnabled: Boolean = true,
   private val onRecipientActionsListener: OnRecipientActionsListener? = null
-) :
-  ListAdapter<RecipientEntity.WithPgpMarker, RecipientsRecyclerViewAdapter.ViewHolder>(
-    DiffUtilCallBack()
-  ) {
-
+) : ListAdapter<RecipientEntity.WithPgpMarker, RecipientsRecyclerViewAdapter.ViewHolder>(
+  DIFF_CALLBACK
+) {
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-    val view =
+    return ViewHolder(
       LayoutInflater.from(parent.context).inflate(R.layout.contact_item, parent, false)
-    return ViewHolder(view)
+    )
   }
 
   override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -44,42 +41,38 @@ class RecipientsRecyclerViewAdapter(
   }
 
   inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    private val tVName: TextView = itemView.findViewById(R.id.tVName)
-    private val tVEmail: TextView = itemView.findViewById(R.id.tVEmail)
-    private val tVOnlyEmail: TextView = itemView.findViewById(R.id.tVOnlyEmail)
-    private val iBtDeleteContact: ImageButton = itemView.findViewById(R.id.iBtDeleteContact)
-    private val imageViewPgp: ImageView = itemView.findViewById(R.id.imageViewPgp)
+    private val binding = ContactItemBinding.bind(itemView)
 
     fun bind(
       recipientEntity: RecipientEntity.WithPgpMarker,
       onRecipientActionsListener: OnRecipientActionsListener?
     ) {
       if (recipientEntity.name.isNullOrEmpty()) {
-        tVName.gone()
-        tVEmail.gone()
-        tVOnlyEmail.visible()
-        tVOnlyEmail.text = recipientEntity.email
-        tVEmail.text = null
-        tVName.text = null
+        binding.tVName.gone()
+        binding.tVEmail.gone()
+        binding.tVOnlyEmail.visible()
+        binding.tVOnlyEmail.text = recipientEntity.email
+        binding.tVEmail.text = null
+        binding.tVName.text = null
       } else {
-        tVName.visible()
-        tVEmail.visible()
-        tVOnlyEmail.gone()
-        tVEmail.text = recipientEntity.email
-        tVName.text = recipientEntity.name
-        tVOnlyEmail.text = null
+        binding.tVName.visible()
+        binding.tVEmail.visible()
+        binding.tVOnlyEmail.gone()
+        binding.tVEmail.text = recipientEntity.email
+        binding.tVName.text = recipientEntity.name
+        binding.tVOnlyEmail.text = null
       }
 
       if (isDeleteEnabled) {
-        iBtDeleteContact.visible()
-        iBtDeleteContact.setOnClickListener {
+        binding.iBtDeleteContact.visible()
+        binding.iBtDeleteContact.setOnClickListener {
           onRecipientActionsListener?.onDeleteRecipient(recipientEntity)
         }
       } else {
-        iBtDeleteContact.gone()
+        binding.iBtDeleteContact.invisible()
       }
 
-      imageViewPgp.visibleOrGone(recipientEntity.hasPgp)
+      binding.imageViewPgp.visibleOrGone(recipientEntity.hasPgp)
 
       itemView.setOnClickListener {
         onRecipientActionsListener?.onRecipientClick(recipientEntity)
@@ -92,17 +85,17 @@ class RecipientsRecyclerViewAdapter(
     fun onRecipientClick(recipientEntityWithPgpMarker: RecipientEntity.WithPgpMarker)
   }
 
-  class DiffUtilCallBack : DiffUtil.ItemCallback<RecipientEntity.WithPgpMarker>() {
-    override fun areItemsTheSame(
-      oldItem: RecipientEntity.WithPgpMarker,
-      newItem: RecipientEntity.WithPgpMarker
-    ) =
-      oldItem.email == newItem.email
+  companion object {
+    private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<RecipientEntity.WithPgpMarker>() {
+      override fun areItemsTheSame(
+        oldItem: RecipientEntity.WithPgpMarker,
+        newItem: RecipientEntity.WithPgpMarker
+      ) = oldItem.email == newItem.email
 
-    override fun areContentsTheSame(
-      oldItem: RecipientEntity.WithPgpMarker,
-      newItem: RecipientEntity.WithPgpMarker
-    ) =
-      oldItem == newItem
+      override fun areContentsTheSame(
+        oldItem: RecipientEntity.WithPgpMarker,
+        newItem: RecipientEntity.WithPgpMarker
+      ) = oldItem == newItem
+    }
   }
 }

--- a/FlowCrypt/src/main/res/drawable/baseline_content_copy_48.xml
+++ b/FlowCrypt/src/main/res/drawable/baseline_content_copy_48.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+  ~ Contributors: denbond7
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z" />
+</vector>

--- a/FlowCrypt/src/main/res/drawable/baseline_save_48.xml
+++ b/FlowCrypt/src/main/res/drawable/baseline_save_48.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+  ~ Contributors: denbond7
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z" />
+</vector>

--- a/FlowCrypt/src/main/res/drawable/outline_info_48.xml
+++ b/FlowCrypt/src/main/res/drawable/outline_info_48.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+  ~ Contributors: denbond7
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z" />
+</vector>

--- a/FlowCrypt/src/main/res/layout/fragment_private_key_details.xml
+++ b/FlowCrypt/src/main/res/layout/fragment_private_key_details.xml
@@ -27,58 +27,85 @@
             android:animateLayoutChanges="true">
 
             <TextView
-                android:id="@+id/tVHeader"
-                android:layout_width="0dp"
+                android:id="@+id/textViewPublicKeys"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/default_margin_content_small"
-                android:gravity="center"
                 android:text="@string/public_key_below_is_safe_to_share"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <Button
-                android:id="@+id/btnShowPubKey"
-                style="@style/AppWidget.Button.Big"
+            <View
+                android:id="@+id/dividerPublicKeys"
                 android:layout_width="0dp"
-                android:layout_marginTop="@dimen/default_margin_content"
-                android:text="@string/show_public_key"
+                android:layout_height="@dimen/default_single_dip"
+                android:background="?android:attr/listDivider"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/tVHeader" />
+                app:layout_constraintTop_toBottomOf="@+id/textViewPublicKeys" />
+
+            <Button
+                style="?attr/materialIconButtonFilledStyle"
+                android:id="@+id/btnShowPubKey"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/default_margin_content"
+                android:backgroundTint="@color/colorPrimary"
+                android:contentDescription="@string/show_public_key"
+                app:cornerRadius="@dimen/default_margin_small"
+                app:icon="@drawable/outline_info_48"
+                app:iconGravity="textStart"
+                app:iconSize="@dimen/icon_size_big"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintEnd_toStartOf="@+id/btnCopyToClipboard"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintTop_toBottomOf="@+id/dividerPublicKeys" />
 
             <Button
                 android:id="@+id/btnCopyToClipboard"
-                style="@style/AppWidget.Button.Big"
+                style="?attr/materialIconButtonFilledStyle"
                 android:layout_width="0dp"
-                android:layout_marginTop="@dimen/default_margin_content"
-                android:text="@string/copy_to_clipboard"
-                android:textAllCaps="true"
-                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
-                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/btnShowPubKey" />
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/default_margin_content_large"
+                android:layout_marginEnd="@dimen/default_margin_content_big"
+                android:backgroundTint="@color/colorPrimary"
+                android:contentDescription="@string/copy_to_clipboard"
+                app:cornerRadius="@dimen/default_margin_small"
+                app:icon="@drawable/baseline_content_copy_48"
+                app:iconGravity="textStart"
+                app:iconSize="@dimen/icon_size_big"
+                app:layout_constraintBottom_toBottomOf="@+id/btnShowPubKey"
+                app:layout_constraintEnd_toStartOf="@+id/btnSaveToFile"
+                app:layout_constraintStart_toEndOf="@+id/btnShowPubKey"
+                app:layout_constraintTop_toTopOf="@+id/btnShowPubKey" />
 
             <Button
                 android:id="@+id/btnSaveToFile"
-                style="@style/AppWidget.Button.Big"
+                style="?attr/materialIconButtonFilledStyle"
                 android:layout_width="0dp"
-                android:layout_marginTop="@dimen/default_margin_content"
-                android:text="@string/save_to_file"
-                android:textAllCaps="true"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@color/colorPrimary"
+                android:contentDescription="@string/save_to_file"
+                app:cornerRadius="@dimen/default_margin_small"
+                app:icon="@drawable/baseline_save_48"
+                app:iconGravity="textStart"
+                app:iconSize="@dimen/icon_size_big"
+                app:layout_constraintBottom_toBottomOf="@+id/btnShowPubKey"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
-                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/btnCopyToClipboard" />
+                app:layout_constraintStart_toEndOf="@+id/btnCopyToClipboard"
+                app:layout_constraintTop_toTopOf="@+id/btnShowPubKey" />
 
             <TextView
                 android:id="@+id/textViewMasterKey"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:text="Key Info"
+                android:layout_marginTop="@dimen/default_margin_content_large"
+                android:text="@string/key_info"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/btnSaveToFile" />
+                app:layout_constraintTop_toBottomOf="@+id/btnShowPubKey" />
 
             <View
                 android:id="@+id/dividerPrimaryKey"
@@ -93,7 +120,7 @@
                 android:id="@+id/textViewFingerprint"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
+                android:layout_marginTop="@dimen/default_margin_small"
                 android:textIsSelectable="true"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
@@ -180,7 +207,7 @@
                 android:id="@+id/textViewStatusValue"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="5dp"
+                android:layout_marginStart="@dimen/default_margin_small"
                 android:background="@drawable/bg_rectangle_silver_border"
                 android:backgroundTint="@color/orange"
                 android:drawablePadding="@dimen/default_twice_dip"
@@ -193,6 +220,18 @@
                 app:layout_constraintTop_toTopOf="@+id/textViewStatus" />
 
             <TextView
+                android:id="@+id/tVPassPhraseVerification"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/stored_pass_phrase_loading"
+                android:textColor="@color/colorPrimaryLight"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/textViewStatus" />
+
+            <TextView
                 android:id="@+id/textViewUserIDs"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -200,7 +239,7 @@
                 android:text="@string/user_ids"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/textViewStatus" />
+                app:layout_constraintTop_toBottomOf="@+id/tVPassPhraseVerification" />
 
             <View
                 android:id="@+id/dividerUserIds"
@@ -223,18 +262,6 @@
                 tools:itemCount="4"
                 tools:orientation="horizontal" />
 
-            <TextView
-                android:id="@+id/tVPassPhraseVerification"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/default_margin_content_small"
-                android:text="@string/stored_pass_phrase_loading"
-                android:textColor="@color/colorPrimaryLight"
-                android:textIsSelectable="true"
-                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
-                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/recyclerViewUserIds" />
-
             <Button
                 android:id="@+id/btnProvidePassphrase"
                 style="@style/AppWidget.Button.Big"
@@ -245,7 +272,7 @@
                 android:visibility="gone"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/tVPassPhraseVerification"
+                app:layout_constraintTop_toBottomOf="@+id/recyclerViewUserIds"
                 tools:visibility="visible" />
 
             <Button

--- a/FlowCrypt/src/main/res/layout/fragment_private_key_details.xml
+++ b/FlowCrypt/src/main/res/layout/fragment_private_key_details.xml
@@ -33,7 +33,7 @@
                 android:layout_marginTop="@dimen/default_margin_content_small"
                 android:gravity="center"
                 android:text="@string/public_key_below_is_safe_to_share"
-                android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -71,14 +71,100 @@
                 app:layout_constraintTop_toBottomOf="@+id/btnCopyToClipboard" />
 
             <TextView
-                android:id="@+id/tVFingerprint"
+                android:id="@+id/textViewMasterKey"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="Key Info"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/btnSaveToFile" />
+
+            <View
+                android:id="@+id/dividerPrimaryKey"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/default_single_dip"
+                android:background="?android:attr/listDivider"
+                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/textViewMasterKey" />
+
+            <TextView
+                android:id="@+id/textViewFingerprint"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
                 android:textIsSelectable="true"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/btnSaveToFile"
+                app:layout_constraintTop_toBottomOf="@+id/textViewMasterKey"
                 tools:text="Fingerprint: XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX" />
+
+            <TextView
+                android:id="@+id/textViewPrimaryKeyAlgorithm"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/default_margin_content_small"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/textViewFingerprint"
+                tools:text="Algorithm: ELGAMAL_GENERAL/4096" />
+
+            <TextView
+                android:id="@+id/textViewCreationDate"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/default_margin_content_small"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/textViewPrimaryKeyAlgorithm"
+                tools:text="Created: Nov 3, 2017" />
+
+            <TextView
+                android:id="@+id/textViewModificationDate"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/default_margin_content_small"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/textViewCreationDate"
+                tools:text="Modified: Nov 3, 2017" />
+
+            <TextView
+                android:id="@+id/textViewExpirationDate"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/default_margin_content_small"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/textViewModificationDate"
+                tools:text="Expires: Nov 3, 2017" />
+
+            <TextView
+                android:id="@+id/textViewUsableForEncryption"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/default_margin_content_small"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/textViewExpirationDate"
+                tools:text="Usable for encryption: true" />
+
+            <TextView
+                android:id="@+id/textViewUsableForSigning"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/default_margin_content_small"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
+                app:layout_constraintTop_toBottomOf="@+id/textViewUsableForEncryption"
+                tools:text="Usable for signing: true" />
 
             <TextView
                 android:id="@+id/textViewStatus"
@@ -88,7 +174,7 @@
                 android:ellipsize="middle"
                 android:text="@string/status"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/tVFingerprint" />
+                app:layout_constraintTop_toBottomOf="@+id/textViewUsableForSigning" />
 
             <TextView
                 android:id="@+id/textViewStatusValue"
@@ -107,48 +193,35 @@
                 app:layout_constraintTop_toTopOf="@+id/textViewStatus" />
 
             <TextView
-                android:id="@+id/textViewCreationDate"
-                android:layout_width="0dp"
+                android:id="@+id/textViewUserIDs"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/default_margin_content_small"
-                android:textIsSelectable="true"
-                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
+                android:layout_marginTop="24dp"
+                android:text="@string/user_ids"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/textViewStatus"
-                tools:text="Creation date: Nov 3, 2017" />
+                app:layout_constraintTop_toBottomOf="@+id/textViewStatus" />
 
-            <TextView
-                android:id="@+id/textViewModificationDate"
+            <View
+                android:id="@+id/dividerUserIds"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/default_margin_content_small"
-                android:textIsSelectable="true"
+                android:layout_height="@dimen/default_single_dip"
+                android:background="?android:attr/listDivider"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/textViewCreationDate"
-                tools:text="Modification date: Nov 3, 2017" />
+                app:layout_constraintTop_toBottomOf="@+id/textViewUserIDs" />
 
-            <TextView
-                android:id="@+id/textViewExpirationDate"
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewUserIds"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/default_margin_content_small"
-                android:textIsSelectable="true"
+                android:nestedScrollingEnabled="false"
+                android:overScrollMode="never"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/textViewModificationDate"
-                tools:text="Expiration date: Nov 3, 2017" />
-
-            <TextView
-                android:id="@+id/tVUsers"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/default_margin_content_small"
-                android:textIsSelectable="true"
-                app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
-                app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/textViewExpirationDate"
-                tools:text="Users: email@domain.com, email2@domain.com" />
+                app:layout_constraintTop_toBottomOf="@+id/dividerUserIds"
+                tools:itemCount="4"
+                tools:orientation="horizontal" />
 
             <TextView
                 android:id="@+id/tVPassPhraseVerification"
@@ -160,7 +233,7 @@
                 android:textIsSelectable="true"
                 app:layout_constraintEnd_toStartOf="@+id/guidelineRight"
                 app:layout_constraintStart_toStartOf="@+id/guidelineLeft"
-                app:layout_constraintTop_toBottomOf="@+id/tVUsers" />
+                app:layout_constraintTop_toBottomOf="@+id/recyclerViewUserIds" />
 
             <Button
                 android:id="@+id/btnProvidePassphrase"

--- a/FlowCrypt/src/main/res/menu/fragment_pub_key_details.xml
+++ b/FlowCrypt/src/main/res/menu/fragment_pub_key_details.xml
@@ -25,10 +25,17 @@
         app:showAsAction="always" />
 
     <item
+        android:id="@+id/menuActionShow"
+        android:menuCategory="system"
+        android:orderInCategory="2002"
+        android:title="@string/show_public_key"
+        app:showAsAction="ifRoom" />
+
+    <item
         android:id="@+id/menuActionDelete"
         android:icon="@drawable/ic_delete_white_24dp"
         android:menuCategory="system"
-        android:orderInCategory="2002"
+        android:orderInCategory="2003"
         android:title="@string/delete"
         android:visible="false"
         app:showAsAction="ifRoom" />
@@ -36,7 +43,7 @@
     <item
         android:id="@+id/menuActionEdit"
         android:menuCategory="system"
-        android:orderInCategory="2003"
+        android:orderInCategory="2004"
         android:title="@string/edit"
         android:visible="false"
         app:showAsAction="ifRoom" />

--- a/FlowCrypt/src/main/res/menu/fragment_pub_key_details.xml
+++ b/FlowCrypt/src/main/res/menu/fragment_pub_key_details.xml
@@ -30,6 +30,7 @@
         android:menuCategory="system"
         android:orderInCategory="2002"
         android:title="@string/delete"
+        android:visible="false"
         app:showAsAction="ifRoom" />
 
     <item
@@ -37,5 +38,6 @@
         android:menuCategory="system"
         android:orderInCategory="2003"
         android:title="@string/edit"
+        android:visible="false"
         app:showAsAction="ifRoom" />
 </menu>

--- a/FlowCrypt/src/main/res/navigation/nav_graph.xml
+++ b/FlowCrypt/src/main/res/navigation/nav_graph.xml
@@ -313,6 +313,16 @@
     </fragment>
 
     <fragment
+        android:id="@+id/privateToPublicKeyDetailsFragment"
+        android:name="com.flowcrypt.email.ui.activity.fragment.PrivateToPublicKeyDetailsFragment"
+        android:label="@string/pub_key"
+        tools:layout="@layout/fragment_public_key_details">
+        <argument
+            android:name="fingerprint"
+            app:argType="string" />
+    </fragment>
+
+    <fragment
         android:id="@+id/privateKeyDetailsFragment"
         android:name="com.flowcrypt.email.ui.activity.fragment.PrivateKeyDetailsFragment"
         android:label="@string/key_details"
@@ -323,6 +333,9 @@
         <action
             android:id="@+id/action_privateKeyDetailsFragment_to_updatePrivateKeyFragment"
             app:destination="@id/updatePrivateKeyFragment" />
+        <action
+            android:id="@+id/action_privateKeyDetailsFragment_to_privateToPublicKeyDetailsFragment"
+            app:destination="@id/privateToPublicKeyDetailsFragment" />
     </fragment>
 
     <fragment

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -607,6 +607,9 @@
     <string name="never">Некогда</string>
     <string name="capabilities">Возможности:</string>
     <string name="sub_keys">Подключи</string>
+    <string name="usable_for_encryption">Можно использовать для шифрования: %1$s</string>
+    <string name="usable_for_signing">Можно использовать для подписи: %1$s</string>
+    <string name="algorithm">Алгоритм: %1$s</string>
     <plurals name="next_attempt_warning_about_wrong_pass_phrase">
         <item quantity="one">Для Вашей защиты и безопасности данных в настоящее время осталось только %1$d попытка, после чего следует 5-минутный период восстановления.</item>
         <item quantity="few">Для Вашей защиты и безопасности данных в настоящее время осталось только %1$d попытки, после чего следует 5-минутный период восстановления.</item>

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -173,7 +173,6 @@
     <string name="delete_quoted_text">Удалить цитируемый текст</string>
     <string name="delete_message">Удалить сообщение</string>
     <string name="template_creation_date">Дата создания: %1$s</string>
-    <string name="template_modification_date">Дата изменения: %1$s</string>
     <string name="date">Дата</string>
     <string name="please_wait_while_key_will_be_created">Создание ключа, пожалуйста, подождите</string>
     <string name="template_created">Создано: %1$s</string>

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -400,7 +400,6 @@
     <string name="to_receiver">Кому %1$s</string>
     <string name="template_warning_max_total_attachments_size">Общий размер добавленных вложений не должен превышать %1$s</string>
     <string name="use_public_key_from">Использовать открытый ключ из</string>
-    <string name="template_users">Пользователи: %1$s</string>
     <string name="warning">Предупреждение</string>
     <string name="password_quality_weak">слабая</string>
     <string name="wrong_public_key_recorded">Записан неверный открытый ключ. Входящая зашифрованная электронная почта может быть недоступна для чтения.</string>

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -610,6 +610,7 @@
     <string name="usable_for_encryption">Можно использовать для шифрования: %1$s</string>
     <string name="usable_for_signing">Можно использовать для подписи: %1$s</string>
     <string name="algorithm">Алгоритм: %1$s</string>
+    <string name="key_info">Информация о ключе</string>
     <plurals name="next_attempt_warning_about_wrong_pass_phrase">
         <item quantity="one">Для Вашей защиты и безопасности данных в настоящее время осталось только %1$d попытка, после чего следует 5-минутный период восстановления.</item>
         <item quantity="few">Для Вашей защиты и безопасности данных в настоящее время осталось только %1$d попытки, после чего следует 5-минутный период восстановления.</item>

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -172,7 +172,6 @@
     <string name="details">Подробности</string>
     <string name="delete_quoted_text">Удалить цитируемый текст</string>
     <string name="delete_message">Удалить сообщение</string>
-    <string name="template_creation_date">Дата создания: %1$s</string>
     <string name="date">Дата</string>
     <string name="please_wait_while_key_will_be_created">Создание ключа, пожалуйста, подождите</string>
     <string name="template_created">Создано: %1$s</string>

--- a/FlowCrypt/src/main/res/values-uk/strings.xml
+++ b/FlowCrypt/src/main/res/values-uk/strings.xml
@@ -173,7 +173,6 @@
     <string name="details">Подробиці</string>
     <string name="delete_quoted_text">Видалити текст, що цитується</string>
     <string name="delete_message">Видалити повідомлення</string>
-    <string name="template_creation_date">Дата створення: %1$s</string>
     <string name="date">Дата</string>
     <string name="please_wait_while_key_will_be_created">Створення ключа, будь ласка, зачекайте</string>
     <string name="template_created">Створено: %1$s</string>

--- a/FlowCrypt/src/main/res/values-uk/strings.xml
+++ b/FlowCrypt/src/main/res/values-uk/strings.xml
@@ -174,7 +174,6 @@
     <string name="delete_quoted_text">Видалити текст, що цитується</string>
     <string name="delete_message">Видалити повідомлення</string>
     <string name="template_creation_date">Дата створення: %1$s</string>
-    <string name="template_modification_date">Дата модифікації: %1$s</string>
     <string name="date">Дата</string>
     <string name="please_wait_while_key_will_be_created">Створення ключа, будь ласка, зачекайте</string>
     <string name="template_created">Створено: %1$s</string>

--- a/FlowCrypt/src/main/res/values-uk/strings.xml
+++ b/FlowCrypt/src/main/res/values-uk/strings.xml
@@ -401,7 +401,6 @@
     <string name="to_receiver">Кому %1$s</string>
     <string name="template_warning_max_total_attachments_size">Загальний розмір доданих вкладень не повинен перевищувати %1$s</string>
     <string name="use_public_key_from">Використати відкритий ключ з</string>
-    <string name="template_users">Користувачі: %1$s</string>
     <string name="warning">Попередження</string>
     <string name="password_quality_weak">слабка</string>
     <string name="wrong_public_key_recorded">Записаний невірний відкритий ключ. Вхідна зашифрована електронна пошта може бути недоступна для читання.</string>

--- a/FlowCrypt/src/main/res/values-uk/strings.xml
+++ b/FlowCrypt/src/main/res/values-uk/strings.xml
@@ -611,6 +611,7 @@
     <string name="usable_for_encryption">Можна використовувати для шифрування: %1$s</string>
     <string name="usable_for_signing">Можна використовувати для підпису: %1$s</string>
     <string name="algorithm">Алгоритм: %1$s</string>
+    <string name="key_info">Інформація про ключ</string>
     <plurals name="next_attempt_warning_about_wrong_pass_phrase">
         <item quantity="one">Для Вашого захисту та безпеки даних наразі залишилася лише %1$d спроба, а потім 5-хвилинний період відновлення.</item>
         <item quantity="few">Для Вашого захисту та безпеки даних наразі залишилася лише %1$d спроби, а потім 5-хвилинний період відновлення.</item>

--- a/FlowCrypt/src/main/res/values-uk/strings.xml
+++ b/FlowCrypt/src/main/res/values-uk/strings.xml
@@ -608,6 +608,9 @@
     <string name="never">Ніколи</string>
     <string name="capabilities">Застосування:</string>
     <string name="sub_keys">Підключі</string>
+    <string name="usable_for_encryption">Можна використовувати для шифрування: %1$s</string>
+    <string name="usable_for_signing">Можна використовувати для підпису: %1$s</string>
+    <string name="algorithm">Алгоритм: %1$s</string>
     <plurals name="next_attempt_warning_about_wrong_pass_phrase">
         <item quantity="one">Для Вашого захисту та безпеки даних наразі залишилася лише %1$d спроба, а потім 5-хвилинний період відновлення.</item>
         <item quantity="few">Для Вашого захисту та безпеки даних наразі залишилася лише %1$d спроби, а потім 5-хвилинний період відновлення.</item>

--- a/FlowCrypt/src/main/res/values/dimens.xml
+++ b/FlowCrypt/src/main/res/values/dimens.xml
@@ -68,4 +68,5 @@
     <dimen name="height_screenshot">150dp</dimen>
     <dimen name="width_screenshot">100dp</dimen>
     <dimen name="avatar_size">48dp</dimen>
+    <dimen name="icon_size_big">32dp</dimen>
 </resources>

--- a/FlowCrypt/src/main/res/values/strings.xml
+++ b/FlowCrypt/src/main/res/values/strings.xml
@@ -619,6 +619,9 @@
     <string name="capabilities">Capabilities:</string>
     <string name="user_ids" translatable="false">User ID(s)</string>
     <string name="sub_keys">Subkeys</string>
+    <string name="usable_for_encryption">Usable for encryption: %1$s</string>
+    <string name="usable_for_signing">Usable for signing: %1$s</string>
+    <string name="algorithm">Algorithm: %1$s</string>
     <plurals name="next_attempt_warning_about_wrong_pass_phrase">
         <item quantity="one">For your protection and data security, there are currently only %1$d attempt left, followed by a 5-minute cooldown period.</item>
         <item quantity="other">For your protection and data security, there are currently only %1$d attempts left, followed by a 5-minute cooldown period.</item>

--- a/FlowCrypt/src/main/res/values/strings.xml
+++ b/FlowCrypt/src/main/res/values/strings.xml
@@ -292,7 +292,6 @@
     <string name="save_to_file">Save to file</string>
     <string name="show_private_key">Show private key</string>
     <string name="template_fingerprint"><![CDATA[Fingerprint: <font color=\'#B7B7B7\'>%1$s</font>]]></string>
-    <string name="template_creation_date">Key creation: %1$s</string>
     <string name="template_users">Users: %1$s</string>
     <string name="see_backups_to_save_your_private_keys">Not implemented yet, see \"Backups\" to save your private key to file</string>
     <string name="copied">Copied</string>

--- a/FlowCrypt/src/main/res/values/strings.xml
+++ b/FlowCrypt/src/main/res/values/strings.xml
@@ -293,7 +293,6 @@
     <string name="show_private_key">Show private key</string>
     <string name="template_fingerprint"><![CDATA[Fingerprint: <font color=\'#B7B7B7\'>%1$s</font>]]></string>
     <string name="template_creation_date">Key creation: %1$s</string>
-    <string name="template_modification_date">Key modification: %1$s</string>
     <string name="template_users">Users: %1$s</string>
     <string name="see_backups_to_save_your_private_keys">Not implemented yet, see \"Backups\" to save your private key to file</string>
     <string name="copied">Copied</string>

--- a/FlowCrypt/src/main/res/values/strings.xml
+++ b/FlowCrypt/src/main/res/values/strings.xml
@@ -622,6 +622,7 @@
     <string name="usable_for_encryption">Usable for encryption: %1$s</string>
     <string name="usable_for_signing">Usable for signing: %1$s</string>
     <string name="algorithm">Algorithm: %1$s</string>
+    <string name="key_info">Key Info</string>
     <plurals name="next_attempt_warning_about_wrong_pass_phrase">
         <item quantity="one">For your protection and data security, there are currently only %1$d attempt left, followed by a 5-minute cooldown period.</item>
         <item quantity="other">For your protection and data security, there are currently only %1$d attempts left, followed by a 5-minute cooldown period.</item>

--- a/FlowCrypt/src/main/res/values/strings.xml
+++ b/FlowCrypt/src/main/res/values/strings.xml
@@ -292,7 +292,6 @@
     <string name="save_to_file">Save to file</string>
     <string name="show_private_key">Show private key</string>
     <string name="template_fingerprint"><![CDATA[Fingerprint: <font color=\'#B7B7B7\'>%1$s</font>]]></string>
-    <string name="template_users">Users: %1$s</string>
     <string name="see_backups_to_save_your_private_keys">Not implemented yet, see \"Backups\" to save your private key to file</string>
     <string name="copied">Copied</string>
     <string name="saved">Saved</string>


### PR DESCRIPTION
This PR Improved the private key details screen UI

close #2506

before 

![image](https://github.com/FlowCrypt/flowcrypt-android/assets/2863246/185866e3-059e-4556-9def-87b0431763f1)

after

![image](https://github.com/FlowCrypt/flowcrypt-android/assets/2863246/d74ed6e9-89cc-499f-a85e-9613aa5f0f17)

Click on 
![image](https://github.com/FlowCrypt/flowcrypt-android/assets/2863246/601d061e-efbb-440b-8384-f3fc6d5f0039)
opens public keys details screen where a user can see more details

![image](https://github.com/FlowCrypt/flowcrypt-android/assets/2863246/28ad7378-a203-44b8-8bbe-45b4b545baa1)


----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
