### PR TITLE
Fixed App crashing when try to preview an encrypted attachment

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/jetpack/viewmodel/DownloadAttachmentViewModel.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/jetpack/viewmodel/DownloadAttachmentViewModel.kt
@@ -157,7 +157,7 @@ class DownloadAttachmentViewModel(val attachmentInfo: AttachmentInfo, applicatio
       downloadAttachmentMutableStateFlow.value =
         Result.loading(progressMsg = context.getString(R.string.decrypting))
 
-      return@withContext decryptDataIfNeeded(context, inputStream)
+      return@withContext super.decryptDataIfNeeded(context, inputStream)
     }
 
   private suspend fun downloadFile(inputStream: InputStream): ByteArray =


### PR DESCRIPTION
This PR Fixed App crashing when try to preview an encrypted attachment

close #2596

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test. Success means after clicking on the 'preview' button the app moves a user to another app that can handle the downloaded attachment. But Espresso can work only with its app. Tested manually.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
