### PR TITLE
Use 'registry.semaphoreci.com/android:29' container instead of manual setup

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="gradleJvm" value="17 (3)" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -116,22 +116,6 @@ blocks:
             # run JUnit tests
             - ./script/ci-junit-tests.sh
 
-        - name: 'Instrumentation tests(No email server)'
-          execution_time_limit:
-            minutes: 45
-          matrix:
-            - env_var: EMULATOR
-              values: [ "0", "1", "2", "3" ]
-          commands:
-            # Setup and run an emulator
-            - ./script/ci-setup-and-run-emulator.sh
-            # wait until ready
-            - ./script/ci-wait-for-emulator.sh
-            # Run filtered logging for TestRunner
-            - adb logcat -v color TestRunner:V *:S > ~/logcat_log.txt &
-            # Run instrumentation tests
-            - ./script/ci-instrumentation-tests-without-mailserver.sh 4 $EMULATOR
-
         - name: 'Instrumentation tests(with email server)'
           execution_time_limit:
             minutes: 45
@@ -146,19 +130,6 @@ blocks:
             - adb logcat -v color TestRunner:V *:S > ~/logcat_log.txt &
             # Run instrumentation tests
             - ./script/ci-instrumentation-tests-with-mailserver.sh
-
-        - name: 'Instrumentation tests(enterprise)'
-          execution_time_limit:
-            minutes: 45
-          commands:
-            # Setup and run an emulator
-            - ./script/ci-setup-and-run-emulator.sh
-            #wait until ready
-            - ./script/ci-wait-for-emulator.sh
-            # Run filtered logging for TestRunner
-            - adb logcat -v color TestRunner:V *:S > ~/logcat_log.txt &
-            # Run instrumentation tests
-            - ./script/ci-instrumentation-tests-enterprise.sh
 
       epilogue:
         always:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,14 +30,6 @@ global_job_config:
     commands:
       # fix DNS to ping *.localhost and *.flowcrypt.test
       - sudo apt-get update
-      - sudo apt install -f
-      - sudo apt install -y dnsmasq resolvconf
-      - echo "#added by flowcrypt" | sudo tee -a /etc/dnsmasq.conf
-      - echo "listen-address=127.0.0.1" | sudo tee -a /etc/dnsmasq.conf
-      - echo "address=/flowcrypt.test/127.0.0.1" | sudo tee -a /etc/dnsmasq.conf
-      - echo "address=/wrongssl.test/127.0.0.1" | sudo tee -a /etc/dnsmasq.conf
-      - echo "address=/localhost/127.0.0.1" | sudo tee -a /etc/dnsmasq.conf
-      - sudo systemctl restart dnsmasq
       # print some debug info
       - ping fel.localhost -c 1
       - ping fel.flowcrypt.test -c 1

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,8 +31,6 @@ global_job_config:
       # fix DNS to ping *.localhost and *.flowcrypt.test
       - sudo apt-get update
       # print some debug info
-      - ping fel.localhost -c 1
-      - ping fel.flowcrypt.test -c 1
       # use JAVA 17 by default
       - sem-version java 17
       # general settings

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,6 +4,9 @@ agent:
   machine:
     type: e1-standard-4
     os_image: ubuntu2004
+  containers:
+    - name: main
+      image: 'registry.semaphoreci.com/android:34'
 execution_time_limit:
   minutes: 60
 
@@ -22,7 +25,7 @@ global_job_config:
     - name: SEMAPHORE_GIT_DIR
       value: /home/semaphore/git/flowcrypt-android
     - name: ANDROID_SDK_ROOT
-      value: /home/semaphore/Android/Sdk
+      value: /opt/android-sdk-linux
   prologue:
     commands:
       # fix DNS to ping *.localhost and *.flowcrypt.test
@@ -40,7 +43,6 @@ global_job_config:
       # use JAVA 17 by default
       - sem-version java 17
       # general settings
-      - export PATH=${ANDROID_SDK_ROOT}/emulator:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${ANDROID_SDK_ROOT}/platform-tools:${PATH}
       - sudo rm -rf ~/.rbenv ~/.phpbrew
       - checkout
       # init environment variables

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,6 +30,7 @@ global_job_config:
     commands:
       # fix DNS to ping *.localhost and *.flowcrypt.test
       - sudo apt-get update
+      - sudo apt install -f
       - sudo apt install -y dnsmasq resolvconf
       - echo "#added by flowcrypt" | sudo tee -a /etc/dnsmasq.conf
       - echo "listen-address=127.0.0.1" | sudo tee -a /etc/dnsmasq.conf

--- a/script/ci-install-android-sdk.sh
+++ b/script/ci-install-android-sdk.sh
@@ -1,42 +1,5 @@
 #!/bin/bash
 
-set -euxo pipefail
-
-if [[ -d ~/.android ]]
-then
-     echo "~/.android already exists"
-else
-     mkdir ~/.android
-     touch ~/.android/repositories.cfg
-fi
-
-SDK_ARCHIVE=commandlinetools-linux-8512546_latest.zip
-
-sudo apt-get -qq install qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils > /dev/null
-sudo kvm-ok
-
-if [[ -d ~/Android ]]; then
-    echo "~/Android already exists, skipping installation"
-else
-    echo "~/Android does not exist, installing"
-    mkdir -p $ANDROID_SDK_ROOT
-
-    # download, unpack and remove sdk archive
-    wget https://dl.google.com/android/repository/$SDK_ARCHIVE
-    unzip -qq $SDK_ARCHIVE -d $ANDROID_SDK_ROOT
-    cd $ANDROID_SDK_ROOT/cmdline-tools && mkdir latest && (ls | grep -v latest | xargs mv -t latest)
-    cd $SEMAPHORE_GIT_DIR
-    rm $SDK_ARCHIVE
-
-    # Install Android SDK
-    (echo "yes" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null | grep -v = || true)
-    ( sleep 5; echo "y" ) | (${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;33.0.0" "platforms;android-33" > /dev/null | grep -v = || true)
-    (${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "extras;google;m2repository" | grep -v = || true)
-    (${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "platform-tools" | grep -v = || true)
-    (${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "emulator" | grep -v = || true)
-    (echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "system-images;android-32;google_apis;x86_64" > /dev/null | grep -v = || true)
-fi
-
-#Uncomment this for debug
-#${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list
+# Install Android SDK
+(echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "system-images;android-32;google_apis;x86_64" > /dev/null | grep -v = || true)
 


### PR DESCRIPTION
This PR switched to use 'registry.semaphoreci.com/android:29' container instead of manual setup

close #1084

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
