### PR TITLE
Improved request a private key passphrase when ViewPager is used

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MessageDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MessageDetailsFragment.kt
@@ -1773,7 +1773,7 @@ class MessageDetailsFragment : BaseFragment<FragmentMessageDetailsBinding>(), Pr
 
   private fun observerPassphraseNeededLiveData() {
     msgDetailsViewModel.passphraseNeededLiveData.observe(viewLifecycleOwner) { fingerprintList ->
-      if (fingerprintList.isNotEmpty()) {
+      if (fingerprintList.isNotEmpty() && (if (args.isViewPagerMode) isResumed else true)) {
         showNeedPassphraseDialog(
           requestKey = REQUEST_KEY_FIX_MISSING_PASSPHRASE + args.messageEntity.id?.toString(),
           fingerprints = fingerprintList


### PR DESCRIPTION
This PR added just a quick fix for a better user experience. Before these changes, the app displayed `need passphrase` dialog when we opened a standard message if the next one(or the previous one) was encrypted. It happened due to the `Fragments` lifecycle in `ViewPager`.

close #2697

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
