### PR TITLE
fixed "Unable to start service com.flowcrypt.email.service.PassPhrasesInRAMService"

### DIFF
--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeyDetailsFragmentPassInRamFlexibleTimeFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/PrivateKeyDetailsFragmentPassInRamFlexibleTimeFlowTest.kt
@@ -96,6 +96,9 @@ class PrivateKeyDetailsFragmentPassInRamFlexibleTimeFlowTest : BaseTest() {
 
   @Test
   fun testInMemoryPassPhraseSessionLengthParameter() {
+    //as tests run a bit differently need to run PassPhrasesInRAMService manually at this stage
+    PassPhrasesInRAMService.start(getTargetContext())
+
     onView(withId(R.id.tVPassPhraseVerification))
       .check(matches(withText(getResString(R.string.pass_phrase_not_provided))))
       .check(matches(hasTextColor(R.color.red)))

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/FlowCryptApplication.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/FlowCryptApplication.kt
@@ -117,7 +117,10 @@ class FlowCryptApplication : Application(), Configuration.Provider {
       val hasTemporaryPassPhrases =
         keysStorage.getRawKeys().any { it.passphraseType == KeyEntity.PassphraseType.RAM }
       if (hasTemporaryPassPhrases) {
-        PassPhrasesInRAMService.start(this)
+        if (GeneralUtil.isAppForegrounded()) {
+          //we can run a foreground service only if the app is visible for a user
+          PassPhrasesInRAMService.start(this)
+        }
       } else {
         PassPhrasesInRAMService.stop(this)
       }


### PR DESCRIPTION
This PR fixed "Unable to start service com.flowcrypt.email.service.PassPhrasesInRAMService"

close #2703

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
