### PR TITLE
Removed android.permission.RECEIVE_BOOT_COMPLETED as not used by the app directly

### DIFF
--- a/FlowCrypt/src/main/AndroidManifest.xml
+++ b/FlowCrypt/src/main/AndroidManifest.xml
@@ -18,8 +18,6 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28"
         tools:ignore="ScopedStorage" />
-    <!-- android.permission.RECEIVE_BOOT_COMPLETED will be used by JobScheduler to persists jobs after the device reboot -->
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- android.permission.WAKE_LOCK will be used by classes which extend JobIntentService -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- Request the foreground service permission. Details here


### PR DESCRIPTION
This PR Removed android.permission.RECEIVE_BOOT_COMPLETED

close #2711

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
