### PR TITLE
Issue 2905 password ptorected message compliance

### DIFF
--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseComposeGmailFlow.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseComposeGmailFlow.kt
@@ -503,6 +503,8 @@ abstract class BaseComposeGmailFlow(accountEntity: AccountEntity = BASE_ACCOUNT_
       Thread.sleep(outgoingMessageConfiguration.timeoutBeforeMovingToComposeInMilliseconds)
     }
 
+    Thread.sleep(1000)
+
     //open the compose screen
     onView(withId(R.id.floatActionButtonCompose))
       .check(matches(isDisplayed()))

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseComposeGmailFlow.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/base/BaseComposeGmailFlow.kt
@@ -503,8 +503,6 @@ abstract class BaseComposeGmailFlow(accountEntity: AccountEntity = BASE_ACCOUNT_
       Thread.sleep(outgoingMessageConfiguration.timeoutBeforeMovingToComposeInMilliseconds)
     }
 
-    Thread.sleep(1000)
-
     //open the compose screen
     onView(withId(R.id.floatActionButtonCompose))
       .check(matches(isDisplayed()))

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/BaseComposeScreenPasswordProtectedDisallowedTermsTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/BaseComposeScreenPasswordProtectedDisallowedTermsTest.kt
@@ -83,21 +83,24 @@ open class BaseComposeScreenPasswordProtectedDisallowedTermsTest(
       "[Classification: Data Control: Internal Data Control] Quarter results",
       "Conference information [Classification: Data Control: Internal Data Control]",
       "[Classification: Data Control: Internal Data Control]",
-      "Conference information [Classification: Data Control: Internal Data Control] Android"
+      "aaaa[Classification: Data Control: Internal Data Control]bbb",
+      "[droid]",
+      "check -droid- case",
     )
 
     val NON_MATCHING_SUBJECTS = listOf(
-      "[Classification: Data Control: Internal Data Control]! Quarter results",
-      "Conference information [Classification: Data Control: Internal Data Control])",
-      "([Classification: Data Control: Internal Data Control]",
-      "Conference information ([Classification: Data Control: Internal Data Control]) Android"
+      "[1Classification: Data Control: Internal Data Control] Quarter results",
+      "Conference information [1Classification: Data Control: Internal Data Control]",
+      "[1Classification: Data Control: Internal Data Control]",
+      "aaaa[1Classification: Data Control: Internal Data Control]bbb",
+      "Microdroid androids",
     )
 
     const val ERROR_TEXT =
       "Password-protected messages are disabled, please check $URL"
 
     val TERMS = listOf(
-      "vendor",
+      "droid",
       "[Classification: Data Control: Internal Data Control]",
     )
   }

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/BaseComposeScreenPasswordProtectedDisallowedTermsTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/BaseComposeScreenPasswordProtectedDisallowedTermsTest.kt
@@ -1,0 +1,85 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: denbond7
+ */
+
+package com.flowcrypt.email.ui.gmailapi.passwordprotected
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.pressImeActionButton
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.action.ViewActions.scrollTo
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.flowcrypt.email.R
+import com.flowcrypt.email.TestConstants
+import com.flowcrypt.email.database.entity.AccountEntity
+import com.flowcrypt.email.matchers.CustomMatchers.Companion.withTextViewDrawable
+import com.flowcrypt.email.matchers.TextViewDrawableMatcher
+import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
+import com.flowcrypt.email.ui.base.BaseComposeGmailFlow
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Before
+
+/**
+ * @author Denys Bondarenko
+ */
+open class BaseComposeScreenPasswordProtectedDisallowedTermsTest(
+  accountEntity: AccountEntity = BASE_ACCOUNT_ENTITY
+) : BaseComposeGmailFlow(accountEntity) {
+  override val mockWebServerRule =
+    FlowCryptMockWebServerRule(TestConstants.MOCK_WEB_SERVER_PORT, object : Dispatcher() {
+      override fun dispatch(request: RecordedRequest): MockResponse {
+        return handleCommonAPICalls(request)
+      }
+    })
+
+  @Before
+  fun setUp() {
+    onView(withId(R.id.editTextEmailAddress))
+      .perform(
+        typeText(TestConstants.RECIPIENT_WITHOUT_PUBLIC_KEY_ON_ATTESTER),
+        pressImeActionButton(),
+        closeSoftKeyboard()
+      )
+    //need to leave focus from 'To' field. move the focus to the next view
+    onView(withId(R.id.editTextEmailSubject))
+      .perform(scrollTo(), click())
+
+    onView(withId(R.id.btnSetWebPortalPassword))
+      .check(matches(isDisplayed()))
+      .check(matches(withText(getResString(R.string.tap_to_protect_with_web_portal_password))))
+      .check(
+        matches(
+          withTextViewDrawable(
+            resourceId = R.drawable.ic_password_not_protected_white_24,
+            drawablePosition = TextViewDrawableMatcher.DrawablePosition.LEFT
+          )
+        )
+      ).perform(click())
+
+    onView(withId(R.id.eTPassphrase))
+      .perform(
+        replaceText(PASSWORD),
+        closeSoftKeyboard()
+      )
+
+    onView(withId(R.id.btSetPassword))
+      .perform(click())
+
+    onView(withId(R.id.menuActionSend))
+      .check(matches(isDisplayed()))
+      .perform(click())
+  }
+
+  companion object {
+    private const val PASSWORD = "Qwerty1234@"
+  }
+}

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/BaseComposeScreenPasswordProtectedDisallowedTermsTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/BaseComposeScreenPasswordProtectedDisallowedTermsTest.kt
@@ -51,7 +51,7 @@ open class BaseComposeScreenPasswordProtectedDisallowedTermsTest(
       )
     //need to leave focus from 'To' field. move the focus to the next view
     onView(withId(R.id.editTextEmailSubject))
-      .perform(scrollTo(), replaceText(SUBJECT), click())
+      .perform(scrollTo(), click(), replaceText(MATCHING_SUBJECTS.first()))
 
     onView(withId(R.id.btnSetWebPortalPassword))
       .check(matches(isDisplayed()))
@@ -78,17 +78,27 @@ open class BaseComposeScreenPasswordProtectedDisallowedTermsTest(
   companion object {
     private const val PASSWORD = "Qwerty1234@"
     const val URL = "https://flowcrypt.com"
-    const val SUBJECT =
-      "Android developers from Europe and across the globe will converge this year at droidcon in London"
+
+    val MATCHING_SUBJECTS = listOf(
+      "[Classification: Data Control: Internal Data Control] Quarter results",
+      "Conference information [Classification: Data Control: Internal Data Control]",
+      "[Classification: Data Control: Internal Data Control]",
+      "Conference information [Classification: Data Control: Internal Data Control] Android"
+    )
+
+    val NON_MATCHING_SUBJECTS = listOf(
+      "[Classification: Data Control: Internal Data Control]! Quarter results",
+      "Conference information [Classification: Data Control: Internal Data Control])",
+      "([Classification: Data Control: Internal Data Control]",
+      "Conference information ([Classification: Data Control: Internal Data Control]) Android"
+    )
+
     const val ERROR_TEXT =
       "Password-protected messages are disabled, please check $URL"
 
     val TERMS = listOf(
-      "Droid",
-      "Android",
-      "ANDROID",
-      "android",
-      "AnDroid"
+      "vendor",
+      "[Classification: Data Control: Internal Data Control]",
     )
   }
 }

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/BaseComposeScreenPasswordProtectedDisallowedTermsTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/BaseComposeScreenPasswordProtectedDisallowedTermsTest.kt
@@ -51,7 +51,7 @@ open class BaseComposeScreenPasswordProtectedDisallowedTermsTest(
       )
     //need to leave focus from 'To' field. move the focus to the next view
     onView(withId(R.id.editTextEmailSubject))
-      .perform(scrollTo(), click())
+      .perform(scrollTo(), replaceText(SUBJECT), click())
 
     onView(withId(R.id.btnSetWebPortalPassword))
       .check(matches(isDisplayed()))
@@ -73,13 +73,22 @@ open class BaseComposeScreenPasswordProtectedDisallowedTermsTest(
 
     onView(withId(R.id.btSetPassword))
       .perform(click())
-
-    onView(withId(R.id.menuActionSend))
-      .check(matches(isDisplayed()))
-      .perform(click())
   }
 
   companion object {
     private const val PASSWORD = "Qwerty1234@"
+    const val URL = "https://flowcrypt.com"
+    const val SUBJECT =
+      "Android developers from Europe and across the globe will converge this year at droidcon in London"
+    const val ERROR_TEXT =
+      "Password-protected messages are disabled, please check $URL"
+
+    val TERMS = listOf(
+      "Droid",
+      "Android",
+      "ANDROID",
+      "android",
+      "AnDroid"
+    )
   }
 }

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsErrorTextMissingFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsErrorTextMissingFlowTest.kt
@@ -41,9 +41,9 @@ import org.junit.runner.RunWith
   subject = "",
   isNew = true
 )
-class ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest :
+class ComposeScreenPasswordProtectedDisallowedTermsErrorTextMissingFlowTest :
   BaseComposeScreenPasswordProtectedDisallowedTermsTest(
-    ACCOUNT_ENTITY_WITH_MISSING_OPTIONAL_PROPERTIES
+    ACCOUNT_ENTITY_WITH_MISSING_ERROR_TEXT
   ) {
 
   @get:Rule
@@ -70,6 +70,12 @@ class ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest :
   }
 
   companion object {
-    val ACCOUNT_ENTITY_WITH_MISSING_OPTIONAL_PROPERTIES = BASE_ACCOUNT_ENTITY.copy()
+    val ACCOUNT_ENTITY_WITH_MISSING_ERROR_TEXT =
+      BASE_ACCOUNT_ENTITY.copy(
+        clientConfiguration = BASE_ACCOUNT_ENTITY.clientConfiguration?.copy(
+          disallowPasswordMessagesErrorText = null,
+          disallowPasswordMessagesForTerms = TERMS
+        )
+      )
   }
 }

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsErrorTextMissingFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsErrorTextMissingFlowTest.kt
@@ -7,6 +7,7 @@ package com.flowcrypt.email.ui.gmailapi.passwordprotected
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -64,9 +65,7 @@ class ComposeScreenPasswordProtectedDisallowedTermsErrorTextMissingFlowTest :
     onView(withId(R.id.menuActionSend))
       .check(matches(isDisplayed()))
       .perform(click())
-    onView(
-      withText(getResString(R.string.sending_message_must_not_be_empty))
-    ).check(matches(isDisplayed()))
+    onView(withText(ERROR_TEXT)).check(doesNotExist())
   }
 
   companion object {

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsFlowTest.kt
@@ -10,6 +10,8 @@ import android.content.Intent
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.openLinkWithText
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
@@ -68,24 +70,55 @@ class ComposeScreenPasswordProtectedDisallowedTermsFlowTest :
 
   @Test
   fun testDialogWithErrorText() {
-    onView(withId(R.id.menuActionSend))
-      .check(matches(isDisplayed()))
-      .perform(click())
+    intentsRelease()
 
-    isDialogWithTextDisplayed(
-      decorView,
-      ERROR_TEXT
-    )
+    MATCHING_SUBJECTS.forEach { subject ->
+      onView(withId(R.id.editTextEmailSubject))
+        .perform(scrollTo(), click(), replaceText(subject))
 
-    //test that URL is openable
-    val expectingIntent = allOf(hasAction(Intent.ACTION_VIEW), hasData(URL))
-    //mocking intent to prevent actual navigation during test
-    Intents.intending(expectingIntent).respondWith(Instrumentation.ActivityResult(0, null))
-    //performing action
-    onView(withText(ERROR_TEXT))
-      .perform(openLinkWithText(URL))
-    //asserting our expected intent was recorded
-    Intents.intended(expectingIntent)
+      onView(withId(R.id.menuActionSend))
+        .check(matches(isDisplayed()))
+        .perform(click())
+
+      isDialogWithTextDisplayed(
+        decorView,
+        ERROR_TEXT
+      )
+
+      Intents.init()
+      //test that URL is openable
+      val expectingIntent = allOf(hasAction(Intent.ACTION_VIEW), hasData(URL))
+      //mocking intent to prevent actual navigation during test
+      Intents.intending(expectingIntent).respondWith(Instrumentation.ActivityResult(0, null))
+      //performing action
+      onView(withText(ERROR_TEXT))
+        .perform(openLinkWithText(URL))
+      //asserting our expected intent was recorded
+      Intents.intended(expectingIntent)
+      Thread.sleep(1000)
+      Intents.release()
+
+      onView(withId(android.R.id.button1))
+        .check(matches(isDisplayed()))
+        .perform(click())
+    }
+  }
+
+  @Test
+  fun testDialogWithoutErrorText() {
+    NON_MATCHING_SUBJECTS.forEach { subject ->
+      onView(withId(R.id.editTextEmailSubject))
+        .perform(scrollTo(), click(), replaceText(subject))
+      Thread.sleep(1000)
+
+      onView(withId(R.id.menuActionSend))
+        .check(matches(isDisplayed()))
+        .perform(click())
+
+      onView(
+        withText(getResString(R.string.sending_message_must_not_be_empty))
+      ).check(matches(isDisplayed()))
+    }
   }
 
   companion object {

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsMissingTermsFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsMissingTermsFlowTest.kt
@@ -41,9 +41,9 @@ import org.junit.runner.RunWith
   subject = "",
   isNew = true
 )
-class ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest :
+class ComposeScreenPasswordProtectedDisallowedTermsMissingTermsFlowTest :
   BaseComposeScreenPasswordProtectedDisallowedTermsTest(
-    ACCOUNT_ENTITY_WITH_MISSING_OPTIONAL_PROPERTIES
+    ACCOUNT_ENTITY_WITH_MISSING_TERMS
   ) {
 
   @get:Rule
@@ -70,6 +70,12 @@ class ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest :
   }
 
   companion object {
-    val ACCOUNT_ENTITY_WITH_MISSING_OPTIONAL_PROPERTIES = BASE_ACCOUNT_ENTITY.copy()
+    val ACCOUNT_ENTITY_WITH_MISSING_TERMS =
+      BASE_ACCOUNT_ENTITY.copy(
+        clientConfiguration = BASE_ACCOUNT_ENTITY.clientConfiguration?.copy(
+          disallowPasswordMessagesErrorText = ERROR_TEXT,
+          disallowPasswordMessagesForTerms = null
+        )
+      )
   }
 }

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsMissingTermsFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsMissingTermsFlowTest.kt
@@ -7,6 +7,7 @@ package com.flowcrypt.email.ui.gmailapi.passwordprotected
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -64,9 +65,7 @@ class ComposeScreenPasswordProtectedDisallowedTermsMissingTermsFlowTest :
     onView(withId(R.id.menuActionSend))
       .check(matches(isDisplayed()))
       .perform(click())
-    onView(
-      withText(getResString(R.string.sending_message_must_not_be_empty))
-    ).check(matches(isDisplayed()))
+    onView(withText(ERROR_TEXT)).check(doesNotExist())
   }
 
   companion object {

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest.kt
@@ -1,0 +1,68 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: denbond7
+ */
+
+package com.flowcrypt.email.ui.gmailapi.passwordprotected
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.flowcrypt.email.R
+import com.flowcrypt.email.junit.annotations.OutgoingMessageConfiguration
+import com.flowcrypt.email.rules.AddRecipientsToDatabaseRule
+import com.flowcrypt.email.rules.ClearAppSettingsRule
+import com.flowcrypt.email.rules.GrantPermissionRuleChooser
+import com.flowcrypt.email.rules.RetryRule
+import com.flowcrypt.email.rules.ScreenshotTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+
+/**
+ * @author Denys Bondarenko
+ */
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+@OutgoingMessageConfiguration(
+  to = [],
+  cc = [],
+  bcc = [],
+  message = "",
+  subject = "",
+  isNew = true
+)
+class ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest :
+  BaseComposeScreenPasswordProtectedDisallowedTermsTest(
+    ACCOUNT_ENTITY_WITH_MISSING_OPTIONAL_PROPERTIES
+  ) {
+
+  @get:Rule
+  var ruleChain: TestRule =
+    RuleChain.outerRule(RetryRule.DEFAULT)
+      .around(ClearAppSettingsRule())
+      .around(GrantPermissionRuleChooser.grant(android.Manifest.permission.POST_NOTIFICATIONS))
+      .around(mockWebServerRule)
+      .around(addAccountToDatabaseRule)
+      .around(addPrivateKeyToDatabaseRule)
+      .around(AddRecipientsToDatabaseRule(prepareRecipientsForTest()))
+      .around(addLabelsToDatabaseRule)
+      .around(activityScenarioRule)
+      .around(ScreenshotTestRule())
+
+  @Test
+  fun testMissingOptionalPropertiesInClientConfiguration() {
+    onView(
+      withText(getResString(R.string.text_must_not_be_empty, getResString(R.string.prompt_subject)))
+    ).check(matches(isDisplayed()))
+  }
+
+  companion object {
+    val ACCOUNT_ENTITY_WITH_MISSING_OPTIONAL_PROPERTIES = BASE_ACCOUNT_ENTITY.copy()
+  }
+}

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/gmailapi/passwordprotected/ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest.kt
@@ -7,6 +7,7 @@ package com.flowcrypt.email.ui.gmailapi.passwordprotected
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -64,9 +65,8 @@ class ComposeScreenPasswordProtectedDisallowedTermsNullFlowTest :
     onView(withId(R.id.menuActionSend))
       .check(matches(isDisplayed()))
       .perform(click())
-    onView(
-      withText(getResString(R.string.sending_message_must_not_be_empty))
-    ).check(matches(isDisplayed()))
+
+    onView(withText(ERROR_TEXT)).check(doesNotExist())
   }
 
   companion object {

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfiguration.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfiguration.kt
@@ -1,6 +1,6 @@
 /*
  * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
- * Contributors: DenBond7
+ * Contributors: denbond7
  */
 
 package com.flowcrypt.email.api.retrofit.response.model
@@ -15,7 +15,7 @@ import kotlinx.parcelize.Parcelize
  * @author Denys Bondarenko
  */
 @Parcelize
-data class ClientConfiguration constructor(
+data class ClientConfiguration(
   @Expose val flags: List<ConfigurationProperty>? = null,
   @SerializedName("custom_keyserver_url")
   @Expose val customKeyserverUrl: String? = null,
@@ -30,7 +30,11 @@ data class ClientConfiguration constructor(
   @SerializedName("enforce_keygen_expire_months")
   @Expose val enforceKeygenExpireMonths: Int? = null,
   @SerializedName("in_memory_pass_phrase_session_length")
-  @Expose val inMemoryPassPhraseSessionLength: Int? = null
+  @Expose val inMemoryPassPhraseSessionLength: Int? = null,
+  @SerializedName("disallow_password_messages_for_terms")
+  @Expose val disallowPasswordMessagesForTerms: List<String>? = null,
+  @SerializedName("disallow_password_messages_error_text")
+  @Expose val disallowPasswordMessagesErrorText: String? = null,
 ) : Parcelable {
 
   val inMemoryPassPhraseSessionLengthNormalized: Int?
@@ -201,6 +205,20 @@ data class ClientConfiguration constructor(
    */
   fun shouldHideArmorMeta(): Boolean {
     return hasProperty(ConfigurationProperty.HIDE_ARMOR_META)
+  }
+
+  /**
+   * With this option, the app must check the subjects of composed password-protected email
+   * messages for specified strings(defined in [disallowPasswordMessagesForTerms]).
+   * If any configured terms are found, the application should display an error message
+   * (defined in [disallowPasswordMessagesErrorText])
+   * indicating that the password encryption method is incompatible with the composed message.
+   *
+   * ref https://github.com/FlowCrypt/flowcrypt-android/issues/2905
+   */
+  fun hasRestrictionForPasswordProtectedMessages(): Boolean {
+    return !disallowPasswordMessagesForTerms.isNullOrEmpty()
+        && !disallowPasswordMessagesErrorText.isNullOrEmpty()
   }
 
   fun hasProperty(configurationProperty: ConfigurationProperty): Boolean {

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfiguration.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfiguration.kt
@@ -226,13 +226,19 @@ data class ClientConfiguration(
   }
 
   fun getDisallowPasswordMessagesForTermsRegex(): Regex? {
+    val startAndEntWithAnyNonWordCharacterRegex = "^\\W.*\\W\$".toRegex(RegexOption.IGNORE_CASE)
+
     return disallowPasswordMessagesForTerms?.joinToString(
       separator = "|",
       prefix = "(",
       postfix = ")"
-    ) {
-      val escapedTerm = Regex.escape(it)
-      "(\\s$escapedTerm\\s|^$escapedTerm\\s|\\s$escapedTerm$|^$escapedTerm$)"
+    ) { term ->
+      val escapedTerm = Regex.escape(term)
+      if (startAndEntWithAnyNonWordCharacterRegex.matches(term)) {
+        "($escapedTerm)"
+      } else {
+        "(\\W$escapedTerm\\W)"
+      }
     }?.toRegex(setOf(RegexOption.IGNORE_CASE))
   }
 

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfiguration.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfiguration.kt
@@ -225,6 +225,17 @@ data class ClientConfiguration(
     return flags?.firstOrNull { it == configurationProperty } != null
   }
 
+  fun getDisallowPasswordMessagesForTermsRegex(): Regex? {
+    return disallowPasswordMessagesForTerms?.joinToString(
+      separator = "|",
+      prefix = "(",
+      postfix = ")"
+    ) {
+      val escapedTerm = Regex.escape(it)
+      "(\\s$escapedTerm\\s|^$escapedTerm\\s|\\s$escapedTerm$|^$escapedTerm$)"
+    }?.toRegex(setOf(RegexOption.IGNORE_CASE))
+  }
+
   @Parcelize
   enum class ConfigurationProperty : Parcelable {
     NO_PRV_CREATE,

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
@@ -1,6 +1,6 @@
 /*
  * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
- * Contributors: DenBond7
+ * Contributors: denbond7
  */
 
 package com.flowcrypt.email.ui.activity.fragment
@@ -1568,6 +1568,21 @@ class CreateMessageFragment : BaseFragment<FragmentCreateMessageBinding>(),
             )
           )
           return false
+        }
+
+        if (account?.clientConfiguration?.hasRestrictionForPasswordProtectedMessages() == true) {
+          val terms = account?.clientConfiguration?.disallowPasswordMessagesForTerms ?: emptyList()
+          if (binding?.editTextEmailSubject?.text?.contains(
+              terms.joinToString("|").toRegex(RegexOption.IGNORE_CASE)
+            ) == true
+          ) {
+            showInfoDialog(
+              dialogTitle = "",
+              dialogMsg = account?.clientConfiguration?.disallowPasswordMessagesErrorText,
+              useLinkify = true
+            )
+            return false
+          }
         }
       }
     }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
@@ -1587,11 +1587,8 @@ class CreateMessageFragment : BaseFragment<FragmentCreateMessageBinding>(),
     if (isWebPortalPasswordEnabled &&
       account?.clientConfiguration?.hasRestrictionForPasswordProtectedMessages() == true
     ) {
-      val terms = account?.clientConfiguration?.disallowPasswordMessagesForTerms ?: emptyList()
-      if (binding?.editTextEmailSubject?.text?.contains(
-          terms.joinToString("|").toRegex(RegexOption.IGNORE_CASE)
-        ) == true
-      ) {
+      val termsRegex = account?.clientConfiguration?.getDisallowPasswordMessagesForTermsRegex()
+      if (termsRegex?.find(binding?.editTextEmailSubject?.text ?: "") != null) {
         showInfoDialog(
           dialogTitle = "",
           dialogMsg = account?.clientConfiguration?.disallowPasswordMessagesErrorText,

--- a/FlowCrypt/src/test/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfigurationTest.kt
+++ b/FlowCrypt/src/test/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfigurationTest.kt
@@ -1,0 +1,48 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: denbond7
+ */
+
+package com.flowcrypt.email.api.retrofit.response.model
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * @author Denys Bondarenko
+ */
+class ClientConfigurationTest {
+  @Test
+  fun testGetDisallowPasswordMessagesForTermsRegex() {
+    val clientConfiguration = ClientConfiguration(
+      disallowPasswordMessagesForTerms = listOf(
+        "vendor",
+        "[Classification: Data Control: Internal Data Control]",
+      )
+    )
+
+    val regex = requireNotNull(clientConfiguration.getDisallowPasswordMessagesForTermsRegex())
+
+    val matchingSubjects = listOf(
+      "[Classification: Data Control: Internal Data Control] Quarter results",
+      "Conference information [Classification: Data Control: Internal Data Control]",
+      "[Classification: Data Control: Internal Data Control]",
+      "Conference information [Classification: Data Control: Internal Data Control] Android"
+    )
+
+    val nonMatchingSubjects = listOf(
+      "[Classification: Data Control: Internal Data Control]! Quarter results",
+      "Conference information [Classification: Data Control: Internal Data Control])",
+      "([Classification: Data Control: Internal Data Control]",
+      "Conference information ([Classification: Data Control: Internal Data Control]) Android"
+    )
+    matchingSubjects.forEach { subject ->
+      assertNotNull("Exception in :$subject", regex.find(subject))
+    }
+
+    nonMatchingSubjects.forEach { subject ->
+      assertNull("Exception in :$subject", regex.find(subject))
+    }
+  }
+}

--- a/FlowCrypt/src/test/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfigurationTest.kt
+++ b/FlowCrypt/src/test/java/com/flowcrypt/email/api/retrofit/response/model/ClientConfigurationTest.kt
@@ -17,7 +17,7 @@ class ClientConfigurationTest {
   fun testGetDisallowPasswordMessagesForTermsRegex() {
     val clientConfiguration = ClientConfiguration(
       disallowPasswordMessagesForTerms = listOf(
-        "vendor",
+        "droid",
         "[Classification: Data Control: Internal Data Control]",
       )
     )
@@ -28,14 +28,17 @@ class ClientConfigurationTest {
       "[Classification: Data Control: Internal Data Control] Quarter results",
       "Conference information [Classification: Data Control: Internal Data Control]",
       "[Classification: Data Control: Internal Data Control]",
-      "Conference information [Classification: Data Control: Internal Data Control] Android"
+      "aaaa[Classification: Data Control: Internal Data Control]bbb",
+      "[droid]",
+      "check -droid- case",
     )
 
     val nonMatchingSubjects = listOf(
-      "[Classification: Data Control: Internal Data Control]! Quarter results",
-      "Conference information [Classification: Data Control: Internal Data Control])",
-      "([Classification: Data Control: Internal Data Control]",
-      "Conference information ([Classification: Data Control: Internal Data Control]) Android"
+      "[1Classification: Data Control: Internal Data Control] Quarter results",
+      "Conference information [1Classification: Data Control: Internal Data Control]",
+      "[1Classification: Data Control: Internal Data Control]",
+      "aaaa[1Classification: Data Control: Internal Data Control]bbb",
+      "Microdroid androids",
     )
     matchingSubjects.forEach { subject ->
       assertNotNull("Exception in :$subject", regex.find(subject))


### PR DESCRIPTION
This PR added changes where we check the subjects of composed password-protected email messages for specified strings

close #2905

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
