### PR TITLE
improve handling attachments

### DIFF
--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/MainSettingsFragmentEnterpriseFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/MainSettingsFragmentEnterpriseFlowTest.kt
@@ -6,27 +6,27 @@
 package com.flowcrypt.email.ui.fragment
 
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.flowcrypt.email.R
-import com.flowcrypt.email.base.BaseTest
-import com.flowcrypt.email.junit.annotations.DependsOnMailServer
+import com.flowcrypt.email.TestConstants
 import com.flowcrypt.email.junit.annotations.FlowCryptTestSettings
-import com.flowcrypt.email.rules.AddAccountToDatabaseRule
 import com.flowcrypt.email.rules.ClearAppSettingsRule
+import com.flowcrypt.email.rules.FlowCryptMockWebServerRule
 import com.flowcrypt.email.rules.GrantPermissionRuleChooser
 import com.flowcrypt.email.rules.RetryRule
 import com.flowcrypt.email.rules.ScreenshotTestRule
 import com.flowcrypt.email.ui.activity.MainActivity
+import com.flowcrypt.email.ui.base.BaseGmailApiTest
 import com.flowcrypt.email.util.TestGeneralUtil
-import org.hamcrest.Matchers.allOf
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -39,60 +39,37 @@ import org.junit.runner.RunWith
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 @FlowCryptTestSettings(useCommonIdling = false)
-class MainSettingsFragmentNavigationToSubMenuFlowTest : BaseTest() {
+class MainSettingsFragmentEnterpriseFlowTest :
+  BaseGmailApiTest(BASE_ACCOUNT_ENTITY.copy(useConversationMode = true)) {
   override val activityScenarioRule = activityScenarioRule<MainActivity>(
     TestGeneralUtil.genIntentForNavigationComponent(
       destinationId = R.id.mainSettingsFragment
     )
   )
 
+  override val mockWebServerRule =
+    FlowCryptMockWebServerRule(TestConstants.MOCK_WEB_SERVER_PORT, object : Dispatcher() {
+      override fun dispatch(request: RecordedRequest): MockResponse {
+        return when {
+          else -> handleCommonAPICalls(request)
+        }
+      }
+    })
+
   @get:Rule
   var ruleChain: TestRule = RuleChain
     .outerRule(RetryRule.DEFAULT)
     .around(ClearAppSettingsRule())
     .around(GrantPermissionRuleChooser.grant(android.Manifest.permission.POST_NOTIFICATIONS))
-    .around(AddAccountToDatabaseRule())
+    .around(addAccountToDatabaseRule)
+    .around(addPrivateKeyToDatabaseRule)
     .around(activityScenarioRule)
     .around(ScreenshotTestRule())
 
   @Test
-  @DependsOnMailServer
-  fun testShowBackupsScreen() {
-    checkIsScreenDisplaying(getResString(R.string.backups))
-  }
-
-  @Test
-  fun testShowSecurityScreen() {
-    checkIsScreenDisplaying(getResString(R.string.security_and_privacy))
-  }
-
-  @Test
-  fun testShowContactsScreen() {
-    checkIsScreenDisplaying(getResString(R.string.contacts))
-  }
-
-  @Test
-  fun testShowKeysScreen() {
-    checkIsScreenDisplaying(getResString(R.string.keys))
-  }
-
-  @Test
-  fun testShowAttesterScreen() {
-    checkIsScreenDisplaying(getResString(R.string.attester))
-  }
-
-  @Test
-  fun testShowLegalScreen() {
-    checkIsScreenDisplaying(
-      getResString(R.string.experimental),
-      getResString(R.string.experimental_settings)
-    )
-  }
-
-  @Test
   fun testHiddenOrVisibleItems() {
     onView(withText(getResString(R.string.backups)))
-      .check(matches(isDisplayed()))
+      .check(doesNotExist())
     onView(withText(getResString(R.string.security_and_privacy)))
       .check(matches(isDisplayed()))
     onView(withText(getResString(R.string.contacts)))
@@ -102,20 +79,8 @@ class MainSettingsFragmentNavigationToSubMenuFlowTest : BaseTest() {
     onView(withText(getResString(R.string.attester)))
       .check(matches(isDisplayed()))
     onView(withText(getResString(R.string.general)))
-      .check(matches(isDisplayed()))
+      .check(doesNotExist())
     onView(withText(getResString(R.string.experimental)))
-      .check(matches(isDisplayed()))
-  }
-
-  private fun checkIsScreenDisplaying(screenName: String) {
-    checkIsScreenDisplaying(screenName, screenName)
-  }
-
-  private fun checkIsScreenDisplaying(commandName: String, screenName: String) {
-    onView(withText(commandName))
-      .check(matches(isDisplayed()))
-      .perform(click())
-    onView(allOf(withText(screenName), withParent(withId(R.id.toolbar))))
       .check(matches(isDisplayed()))
   }
 }

--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/MainSettingsFragmentEnterpriseFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/fragment/MainSettingsFragmentEnterpriseFlowTest.kt
@@ -68,8 +68,14 @@ class MainSettingsFragmentEnterpriseFlowTest :
 
   @Test
   fun testHiddenOrVisibleItems() {
+    //should be hidden as we have NO_PRV_BACKUP
     onView(withText(getResString(R.string.backups)))
       .check(doesNotExist())
+    //should be hidden as we have RESTRICT_ANDROID_ATTACHMENT_HANDLING
+    onView(withText(getResString(R.string.general)))
+      .check(doesNotExist())
+
+    //should be visible
     onView(withText(getResString(R.string.security_and_privacy)))
       .check(matches(isDisplayed()))
     onView(withText(getResString(R.string.contacts)))
@@ -78,8 +84,6 @@ class MainSettingsFragmentEnterpriseFlowTest :
       .check(matches(isDisplayed()))
     onView(withText(getResString(R.string.attester)))
       .check(matches(isDisplayed()))
-    onView(withText(getResString(R.string.general)))
-      .check(doesNotExist())
     onView(withText(getResString(R.string.experimental)))
       .check(matches(isDisplayed()))
   }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/Constants.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/Constants.kt
@@ -55,11 +55,14 @@ class Constants {
     const val PREF_KEY_MESSAGES_NOTIFICATION_FILTER = "preferences_key_messages_notification_filter"
     const val PREF_KEY_MANAGE_NOTIFICATIONS = "preferences_key_manage_notifications"
     const val PREF_KEY_SECURITY_CHANGE_PASS_PHRASE = "preferences_key_security_change_pass_phrase"
+    const val PREFERENCES_KEY_ATTACHMENTS_DISABLE_SMART_MODE_FOR_PREVIEW =
+      "preferences_key_attachments_disable_smart_mode_for_preview"
     const val PREF_KEY_LAST_ATT_ORDER_ID = "preferences_key_last_att_order_id"
     const val PREF_KEY_IS_CHECK_KEYS_NEEDED = "preferences_key_is_check_keys_needed"
     const val PREF_KEY_BACKUPS = "pref_key_backups"
     const val PREF_KEY_INSTALL_VERSION = "pref_key_install_version"
     const val PREF_KEY_SERVER_SETTINGS = "pref_key_server_settings"
+    const val PREF_KEY_GENERAL = "pref_key_general"
 
     /**
      * The max total size off all attachment which can be send via the app.

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/providers/EmbeddedAttachmentsProvider.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/providers/EmbeddedAttachmentsProvider.kt
@@ -59,6 +59,12 @@ class EmbeddedAttachmentsProvider : DocumentsProvider() {
     return getFileDescriptor(getBytesForDocumentId(documentId))
   }
 
+  override fun getDocumentType(documentId: String?): String {
+    return documentId?.let {
+      Cache.getInstance().get(documentId)?.type ?: super.getDocumentType(documentId)
+    } ?: super.getDocumentType(documentId)
+  }
+
   private fun getBytesForDocumentId(documentId: String): ByteArray {
     val attachmentInfo = Cache.getInstance().get(documentId)
     return requireNotNull(attachmentInfo?.rawData)

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/service/attachment/AttachmentDownloadManagerService.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/service/attachment/AttachmentDownloadManagerService.kt
@@ -646,13 +646,9 @@ class AttachmentDownloadManagerService : LifecycleService() {
           //we should check maybe a file is already exist.
           //Then we will use the file name from the system.
           if (cursor.moveToFirst()) {
-            val nameIndex = cursor.getColumnIndex(MediaStore.DownloadColumns.DISPLAY_NAME)
-            if (nameIndex != -1) {
-              val nameFromSystem = cursor.getString(nameIndex)
-              if (nameFromSystem != finalFileName) {
-                finalFileName = nameFromSystem
-              }
-            }
+            finalFileName = cursor.getString(
+              cursor.getColumnIndexOrThrow(MediaStore.DownloadColumns.DISPLAY_NAME)
+            )
           }
         }
 

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/service/attachment/AttachmentDownloadManagerService.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/service/attachment/AttachmentDownloadManagerService.kt
@@ -623,23 +623,6 @@ class AttachmentDownloadManagerService : LifecycleService() {
       val fileUri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
 
       requireNotNull(fileUri)
-
-      //we should check maybe a file is already exist. Then we will use the file name from the system
-      val cursor =
-        resolver.query(fileUri, arrayOf(MediaStore.DownloadColumns.DISPLAY_NAME), null, null, null)
-      cursor?.let {
-        if (it.moveToFirst()) {
-          val nameIndex = it.getColumnIndex(MediaStore.DownloadColumns.DISPLAY_NAME)
-          if (nameIndex != -1) {
-            val nameFromSystem = it.getString(nameIndex)
-            if (nameFromSystem != finalFileName) {
-              finalFileName = nameFromSystem
-            }
-          }
-        }
-      }
-      cursor?.close()
-
       val srcInputStream = attFile.inputStream()
       val destOutputStream = resolver.openOutputStream(fileUri)
         ?: throw IllegalArgumentException("provided URI could not be opened")
@@ -651,6 +634,27 @@ class AttachmentDownloadManagerService : LifecycleService() {
       resolver.update(fileUri, ContentValues().apply {
         put(MediaStore.Downloads.IS_PENDING, 0)
       }, null, null)
+
+      resolver.query(
+        fileUri,
+        arrayOf(MediaStore.DownloadColumns.DISPLAY_NAME),
+        null,
+        null,
+        null
+      )
+        ?.use { cursor ->
+          //we should check maybe a file is already exist.
+          //Then we will use the file name from the system.
+          if (cursor.moveToFirst()) {
+            val nameIndex = cursor.getColumnIndex(MediaStore.DownloadColumns.DISPLAY_NAME)
+            if (nameIndex != -1) {
+              val nameFromSystem = cursor.getString(nameIndex)
+              if (nameFromSystem != finalFileName) {
+                finalFileName = nameFromSystem
+              }
+            }
+          }
+        }
 
       return fileUri
     }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
@@ -39,6 +39,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.navArgs
+import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.flowcrypt.email.Constants
@@ -109,6 +110,7 @@ import com.flowcrypt.email.ui.adapter.recyclerview.itemdecoration.MarginItemDeco
 import com.flowcrypt.email.util.FileAndDirectoryUtils
 import com.flowcrypt.email.util.GeneralUtil
 import com.flowcrypt.email.util.LogsUtil
+import com.flowcrypt.email.util.SharedPreferencesHelper
 import com.flowcrypt.email.util.UIUtil
 import com.flowcrypt.email.util.exception.DecryptionException
 import com.flowcrypt.email.util.exception.ExceptionUtil
@@ -255,7 +257,15 @@ class CreateMessageFragment : BaseFragment<FragmentCreateMessageBinding>(),
 
       override fun onPreviewClick(attachmentInfo: AttachmentInfo) {
         if (attachmentInfo.uri != null) {
-          val intent = GeneralUtil.genViewAttachmentIntent(attachmentInfo.uri, attachmentInfo)
+          val intent = GeneralUtil.genViewAttachmentIntent(
+            uri = attachmentInfo.uri,
+            attachmentInfo = attachmentInfo,
+            useCommonPattern = SharedPreferencesHelper.getBoolean(
+              sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext()),
+              key = Constants.PREFERENCES_KEY_ATTACHMENTS_DISABLE_SMART_MODE_FOR_PREVIEW,
+              defaultValue = false
+            )
+          )
           try {
             startActivity(intent)
           } catch (e: ActivityNotFoundException) {

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/CreateMessageFragment.kt
@@ -253,10 +253,6 @@ class CreateMessageFragment : BaseFragment<FragmentCreateMessageBinding>(),
     attachmentActionListener = object : AttachmentsRecyclerViewAdapter.AttachmentActionListener {
       override fun onDownloadClick(attachmentInfo: AttachmentInfo) {}
 
-      override fun onAttachmentClick(attachmentInfo: AttachmentInfo) {
-        onPreviewClick(attachmentInfo)
-      }
-
       override fun onPreviewClick(attachmentInfo: AttachmentInfo) {
         if (attachmentInfo.uri != null) {
           val intent = GeneralUtil.genViewAttachmentIntent(attachmentInfo.uri, attachmentInfo)

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MainSettingsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MainSettingsFragment.kt
@@ -1,6 +1,6 @@
 /*
  * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
- * Contributors: DenBond7
+ * Contributors: denbond7
  */
 
 package com.flowcrypt.email.ui.activity.fragment
@@ -95,6 +95,14 @@ class MainSettingsFragment : BasePreferenceFragment() {
         true
       }
 
+    findPreference<Preference>(getString(R.string.pref_key_general))
+      ?.setOnPreferenceClickListener {
+        navController?.navigate(
+          MainSettingsFragmentDirections.actionMainSettingsFragmentToGeneralSettingsFragment()
+        )
+        true
+      }
+
     findPreference<Preference>(getString(R.string.pref_key_experimental))
       ?.setOnPreferenceClickListener {
         navController?.navigate(
@@ -110,8 +118,10 @@ class MainSettingsFragment : BasePreferenceFragment() {
       !(accountEntity?.hasClientConfigurationProperty(ClientConfiguration.ConfigurationProperty.NO_PRV_BACKUP)
         ?: false)
 
-    if (accountEntity?.useAPI == false) {
-      findPreference<Preference>(Constants.PREF_KEY_SERVER_SETTINGS)?.isVisible = true
-    }
+    findPreference<Preference>(Constants.PREF_KEY_SERVER_SETTINGS)?.isVisible =
+      accountEntity?.useAPI == false
+
+    findPreference<Preference>(Constants.PREF_KEY_GENERAL)?.isVisible =
+      accountEntity?.isHandlingAttachmentRestricted() == false
   }
 }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MessageDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MessageDetailsFragment.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.navArgs
+import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.flowcrypt.email.Constants
@@ -131,6 +132,7 @@ import com.flowcrypt.email.ui.widget.EmailWebView
 import com.flowcrypt.email.ui.widget.TileDrawable
 import com.flowcrypt.email.util.DateTimeUtil
 import com.flowcrypt.email.util.GeneralUtil
+import com.flowcrypt.email.util.SharedPreferencesHelper
 import com.flowcrypt.email.util.UIUtil
 import com.flowcrypt.email.util.exception.CommonConnectionException
 import com.flowcrypt.email.util.exception.GmailAPIException
@@ -1824,7 +1826,15 @@ class MessageDetailsFragment : BaseFragment<FragmentMessageDetailsBinding>(), Pr
     useContentApp: Boolean = false
   ) {
     val intent = if (attachmentInfo.uri != null) {
-      GeneralUtil.genViewAttachmentIntent(requireNotNull(attachmentInfo.uri), attachmentInfo)
+      GeneralUtil.genViewAttachmentIntent(
+        uri = requireNotNull(attachmentInfo.uri),
+        attachmentInfo = attachmentInfo,
+        useCommonPattern = SharedPreferencesHelper.getBoolean(
+          sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext()),
+          key = Constants.PREFERENCES_KEY_ATTACHMENTS_DISABLE_SMART_MODE_FOR_PREVIEW,
+          defaultValue = false
+        )
+      )
     } else {
       toast(getString(R.string.preview_is_not_available))
       return

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MessageDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/MessageDetailsFragment.kt
@@ -201,10 +201,6 @@ class MessageDetailsFragment : BaseFragment<FragmentMessageDetailsBinding>(), Pr
         }
       }
 
-      override fun onAttachmentClick(attachmentInfo: AttachmentInfo) {
-        onPreviewClick(attachmentInfo)
-      }
-
       override fun onPreviewClick(attachmentInfo: AttachmentInfo) {
         if (attachmentInfo.uri != null) {
           if (attachmentInfo.isPossiblyEncrypted) {

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/ThreadDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/ThreadDetailsFragment.kt
@@ -1292,6 +1292,13 @@ class ThreadDetailsFragment : BaseFragment<FragmentThreadDetailsBinding>(), Prog
 
   private fun previewAttachment(attachmentInfo: AttachmentInfo) {
     val intent = if (attachmentInfo.uri != null) {
+      toast(
+        "Debug: Original = ${attachmentInfo.type}, final = ${
+          Intent.normalizeMimeType(
+            attachmentInfo.type
+          )
+        }"
+      )
       GeneralUtil.genViewAttachmentIntent(requireNotNull(attachmentInfo.uri), attachmentInfo)
     } else {
       toast(getString(R.string.preview_is_not_available))

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/ThreadDetailsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/ThreadDetailsFragment.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.navArgs
+import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.work.WorkManager
 import com.flowcrypt.email.Constants
@@ -95,6 +96,7 @@ import com.flowcrypt.email.ui.adapter.MessagesInThreadListAdapter
 import com.flowcrypt.email.ui.adapter.recyclerview.itemdecoration.SkipFirstAndLastDividerItemDecoration
 import com.flowcrypt.email.util.FileAndDirectoryUtils
 import com.flowcrypt.email.util.GeneralUtil
+import com.flowcrypt.email.util.SharedPreferencesHelper
 import com.flowcrypt.email.util.exception.ThreadNotFoundException
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import org.apache.commons.io.FilenameUtils
@@ -1292,14 +1294,15 @@ class ThreadDetailsFragment : BaseFragment<FragmentThreadDetailsBinding>(), Prog
 
   private fun previewAttachment(attachmentInfo: AttachmentInfo) {
     val intent = if (attachmentInfo.uri != null) {
-      toast(
-        "Debug: Original = ${attachmentInfo.type}, final = ${
-          Intent.normalizeMimeType(
-            attachmentInfo.type
-          )
-        }"
+      GeneralUtil.genViewAttachmentIntent(
+        uri = requireNotNull(attachmentInfo.uri),
+        attachmentInfo = attachmentInfo,
+        useCommonPattern = SharedPreferencesHelper.getBoolean(
+          sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext()),
+          key = Constants.PREFERENCES_KEY_ATTACHMENTS_DISABLE_SMART_MODE_FOR_PREVIEW,
+          defaultValue = false
+        )
       )
-      GeneralUtil.genViewAttachmentIntent(requireNotNull(attachmentInfo.uri), attachmentInfo)
     } else {
       toast(getString(R.string.preview_is_not_available))
       return

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/preferences/GeneralSettingsFragment.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/activity/fragment/preferences/GeneralSettingsFragment.kt
@@ -1,0 +1,28 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: denbond7
+ */
+
+package com.flowcrypt.email.ui.activity.fragment.preferences
+
+import android.os.Bundle
+import android.view.View
+import com.flowcrypt.email.R
+import com.flowcrypt.email.extensions.androidx.fragment.app.supportActionBar
+import com.flowcrypt.email.ui.activity.fragment.base.BasePreferenceFragment
+
+/**
+ * This class describes general settings.
+ *
+ * @author Denys Bondarenko
+ */
+open class GeneralSettingsFragment : BasePreferenceFragment() {
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    supportActionBar?.title = getString(R.string.general)
+  }
+
+  override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+    setPreferencesFromResource(R.xml.preferences_general_settings, rootKey)
+  }
+}

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/adapter/AttachmentsRecyclerViewAdapter.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/adapter/AttachmentsRecyclerViewAdapter.kt
@@ -1,6 +1,6 @@
 /*
  * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
- * Contributors: DenBond7
+ * Contributors: denbond7
  */
 
 package com.flowcrypt.email.ui.adapter
@@ -76,10 +76,6 @@ class AttachmentsRecyclerViewAdapter(
         attachmentActionListener.onDeleteClick(attachmentInfo)
       }
 
-      itemView.setOnClickListener {
-        attachmentActionListener.onAttachmentClick(attachmentInfo)
-      }
-
       val value = progressMap[attachmentInfo.uniqueStringId]
       if (value?.progressInPercentage in 0..99) {
         imageViewAttIcon.setImageResource(R.drawable.stat_sys_download_blue)
@@ -103,7 +99,6 @@ class AttachmentsRecyclerViewAdapter(
 
   interface AttachmentActionListener {
     fun onDownloadClick(attachmentInfo: AttachmentInfo)
-    fun onAttachmentClick(attachmentInfo: AttachmentInfo)
     fun onPreviewClick(attachmentInfo: AttachmentInfo)
     fun onDeleteClick(attachmentInfo: AttachmentInfo)
   }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/ui/adapter/MessagesInThreadListAdapter.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/ui/adapter/MessagesInThreadListAdapter.kt
@@ -418,8 +418,6 @@ class MessagesInThreadListAdapter(
             onMessageActionsListener.onAttachmentDownloadClick(attachmentInfo, message)
           }
 
-          override fun onAttachmentClick(attachmentInfo: AttachmentInfo) {}
-
           override fun onPreviewClick(attachmentInfo: AttachmentInfo) {
             onMessageActionsListener.onAttachmentPreviewClick(attachmentInfo, message)
           }

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/util/FileAndDirectoryUtils.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/util/FileAndDirectoryUtils.kt
@@ -1,10 +1,12 @@
 /*
  * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
- * Contributors: DenBond7
+ * Contributors: denbond7
  */
 
 package com.flowcrypt.email.util
 
+import android.content.Context
+import android.provider.MediaStore
 import org.apache.commons.io.FilenameUtils
 import java.io.File
 import java.io.IOException
@@ -17,6 +19,21 @@ import java.util.regex.Pattern
  * @author Denys Bondarenko
  */
 class FileAndDirectoryUtils {
+  object Downloads {
+    fun isFileAlreadyExist(context: Context, fileName: String): Boolean {
+      return context.contentResolver.query(
+        MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+        arrayOf(
+          MediaStore.Files.FileColumns._ID,
+          MediaStore.Files.FileColumns.DISPLAY_NAME
+        ),
+        MediaStore.Downloads.DISPLAY_NAME + " = ?",
+        arrayOf(fileName),
+        null
+      )?.use { it.moveToNext() } ?: false
+    }
+  }
+
   companion object {
     /**
      * Cleans an input directory.

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/util/GeneralUtil.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/util/GeneralUtil.kt
@@ -474,7 +474,7 @@ class GeneralUtil {
       Intent.createChooser(
         Intent()
         .setAction(Intent.ACTION_VIEW)
-          .setDataAndType(uri, "*/*")
+          .setDataAndType(uri, "image/jpg")
         .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
           .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION), null
       )

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/util/GeneralUtil.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/util/GeneralUtil.kt
@@ -470,14 +470,26 @@ class GeneralUtil {
         }
       }
 
-    fun genViewAttachmentIntent(uri: Uri, attachmentInfo: AttachmentInfo): Intent =
-      Intent.createChooser(
+    fun genViewAttachmentIntent(
+      uri: Uri,
+      attachmentInfo: AttachmentInfo,
+      useCommonPattern: Boolean = false
+    ): Intent {
+      return Intent.createChooser(
         Intent()
-        .setAction(Intent.ACTION_VIEW)
-          .setDataAndType(uri, "image/jpg")
-        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+          .setAction(Intent.ACTION_VIEW)
+          .setDataAndType(
+            uri,
+            if (useCommonPattern) {
+              "*/*"
+            } else {
+              Intent.normalizeMimeType(attachmentInfo.type)
+            }
+          )
+          .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
           .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION), null
       )
+    }
 
     suspend fun getGoogleIdTokenSilently(
       context: Context,

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/util/GeneralUtil.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/util/GeneralUtil.kt
@@ -470,12 +470,14 @@ class GeneralUtil {
         }
       }
 
-    fun genViewAttachmentIntent(uri: Uri, attachmentInfo: AttachmentInfo) =
-      Intent()
+    fun genViewAttachmentIntent(uri: Uri, attachmentInfo: AttachmentInfo): Intent =
+      Intent.createChooser(
+        Intent()
         .setAction(Intent.ACTION_VIEW)
-        .setDataAndType(uri, Intent.normalizeMimeType(attachmentInfo.type))
+          .setDataAndType(uri, "*/*")
         .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+          .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION), null
+      )
 
     suspend fun getGoogleIdTokenSilently(
       context: Context,

--- a/FlowCrypt/src/main/res/drawable/bg_att.xml
+++ b/FlowCrypt/src/main/res/drawable/bg_att.xml
@@ -5,8 +5,6 @@
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!--<item android:drawable="?android:attr/selectableItemBackground" />-->
-
     <item>
         <shape android:shape="rectangle">
             <stroke

--- a/FlowCrypt/src/main/res/drawable/bg_att.xml
+++ b/FlowCrypt/src/main/res/drawable/bg_att.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
-  ~ Contributors: DenBond7
+  ~ Contributors: denbond7
   -->
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="?android:attr/selectableItemBackground" />
+
+    <!--<item android:drawable="?android:attr/selectableItemBackground" />-->
 
     <item>
         <shape android:shape="rectangle">

--- a/FlowCrypt/src/main/res/drawable/bg_att_decrypted.xml
+++ b/FlowCrypt/src/main/res/drawable/bg_att_decrypted.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
-  ~ Contributors: DenBond7
+  ~ Contributors: denbond7
   -->
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:drawable="?android:attr/selectableItemBackground" />
+    <!--<item android:drawable="?android:attr/selectableItemBackground" />-->
 
     <item android:gravity="left">
         <shape>

--- a/FlowCrypt/src/main/res/drawable/bg_att_decrypted.xml
+++ b/FlowCrypt/src/main/res/drawable/bg_att_decrypted.xml
@@ -5,8 +5,6 @@
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!--<item android:drawable="?android:attr/selectableItemBackground" />-->
-
     <item android:gravity="left">
         <shape>
             <size android:width="@dimen/width_pgp_message_type_line" />

--- a/FlowCrypt/src/main/res/navigation/nav_graph.xml
+++ b/FlowCrypt/src/main/res/navigation/nav_graph.xml
@@ -145,6 +145,9 @@
         <action
             android:id="@+id/action_mainSettingsFragment_to_signatureSettingsFragment"
             app:destination="@id/signatureSettingsFragment" />
+        <action
+            android:id="@+id/action_mainSettingsFragment_to_generalSettingsFragment"
+            app:destination="@id/generalSettingsFragment" />
     </fragment>
 
     <fragment
@@ -277,6 +280,11 @@
         android:name="com.flowcrypt.email.ui.activity.fragment.LegalSettingsFragment"
         android:label="@string/legal"
         tools:layout="@layout/fragment_legal" />
+
+    <fragment
+        android:id="@+id/generalSettingsFragment"
+        android:name="com.flowcrypt.email.ui.activity.fragment.preferences.GeneralSettingsFragment"
+        android:label="@string/general" />
 
     <fragment
         android:id="@+id/serverSettingsFragment"

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -643,7 +643,7 @@
     <string name="draft">Черновик</string>
     <string name="delete_draft">Удалить черновик?</string>
     <string name="thread_was_deleted_or_moved">Переписка удалена или перемещена</string>
-    <string name="file_already_exists_in_download">\'%1$s\' уже существует Download. Хотите загрузить его снова?</string>
+    <string name="file_already_exists_in_download">\'%1$s\' уже существует в Download. Хотите загрузить его снова?</string>
     <plurals name="drafts_count">
         <item quantity="one" tools:ignore="ImpliedQuantity">Черновик</item>
         <item quantity="few">Черновики(%1$d)</item>

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -644,6 +644,8 @@
     <string name="delete_draft">Удалить черновик?</string>
     <string name="thread_was_deleted_or_moved">Переписка удалена или перемещена</string>
     <string name="file_already_exists_in_download">\'%1$s\' уже существует в Download. Хотите загрузить его снова?</string>
+    <string name="general">Общиe</string>
+    <string name="disable_smart_mode_for_attachments_preview">Отключить интеллектуальный режим для предварительного просмотра вложений</string>
     <plurals name="drafts_count">
         <item quantity="one" tools:ignore="ImpliedQuantity">Черновик</item>
         <item quantity="few">Черновики(%1$d)</item>

--- a/FlowCrypt/src/main/res/values-ru/strings.xml
+++ b/FlowCrypt/src/main/res/values-ru/strings.xml
@@ -643,6 +643,7 @@
     <string name="draft">Черновик</string>
     <string name="delete_draft">Удалить черновик?</string>
     <string name="thread_was_deleted_or_moved">Переписка удалена или перемещена</string>
+    <string name="file_already_exists_in_download">\'%1$s\' уже существует Download. Хотите загрузить его снова?</string>
     <plurals name="drafts_count">
         <item quantity="one" tools:ignore="ImpliedQuantity">Черновик</item>
         <item quantity="few">Черновики(%1$d)</item>

--- a/FlowCrypt/src/main/res/values-uk/strings.xml
+++ b/FlowCrypt/src/main/res/values-uk/strings.xml
@@ -644,6 +644,7 @@
     <string name="draft">Чорновик</string>
     <string name="delete_draft">Видалити чернетку?</string>
     <string name="thread_was_deleted_or_moved">Бесіду видалено або переміщено</string>
+    <string name="file_already_exists_in_download">\'%1$s\' уже існує в Download. Бажаєте завантажити його знову?</string>
     <plurals name="drafts_count">
         <item quantity="one" tools:ignore="ImpliedQuantity">Чорновик</item>
         <item quantity="few">Чорновики(%1$d)</item>

--- a/FlowCrypt/src/main/res/values-uk/strings.xml
+++ b/FlowCrypt/src/main/res/values-uk/strings.xml
@@ -645,6 +645,8 @@
     <string name="delete_draft">Видалити чернетку?</string>
     <string name="thread_was_deleted_or_moved">Бесіду видалено або переміщено</string>
     <string name="file_already_exists_in_download">\'%1$s\' уже існує в Download. Бажаєте завантажити його знову?</string>
+    <string name="general">Загальні</string>
+    <string name="disable_smart_mode_for_attachments_preview">Вимкнути розумний режим для попереднього перегляду вкладень</string>
     <plurals name="drafts_count">
         <item quantity="one" tools:ignore="ImpliedQuantity">Чорновик</item>
         <item quantity="few">Чорновики(%1$d)</item>

--- a/FlowCrypt/src/main/res/values/preferences.xml
+++ b/FlowCrypt/src/main/res/values/preferences.xml
@@ -1,13 +1,15 @@
 <!--
   ~ © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
-  ~ Contributors: DenBond7
+  ~ Contributors: denbond7
   -->
 
 <resources>
     <string name="preferences_key_messages_notification_filter" translatable="false">preferences_key_messages_notification_filter</string>
     <string name="preferences_key_manage_notifications" translatable="false">preferences_key_manage_notifications</string>
     <string name="preferences_key_security_change_pass_phrase" translatable="false">preferences_key_security_change_pass_phrase</string>
+    <string name="preferences_key_attachments_disable_smart_mode_for_preview" translatable="false">preferences_key_attachments_disable_smart_mode_for_preview</string>
     <string name="pref_key_backups" translatable="false">pref_key_backups</string>
+    <string name="pref_key_general" translatable="false">pref_key_general</string>
     <string name="pref_key_server_settings" translatable="false">pref_key_server_settings</string>
     <string name="pref_key_attester" translatable="false">pref_key_attester</string>
     <string name="pref_key_legal" translatable="false">pref_key_legal</string>

--- a/FlowCrypt/src/main/res/values/strings.xml
+++ b/FlowCrypt/src/main/res/values/strings.xml
@@ -654,6 +654,8 @@
     <string name="delete_draft">Delete draft?</string>
     <string name="thread_was_deleted_or_moved">The thread was deleted or moved</string>
     <string name="file_already_exists_in_download">\'%1$s\' already exists in Download. Would you like to download it again?</string>
+    <string name="general">General</string>
+    <string name="disable_smart_mode_for_attachments_preview">Disable smart mode for attachments preview</string>
     <plurals name="drafts_count">
         <item quantity="one">Draft</item>
         <item quantity="other">Drafts(%1$d)</item>

--- a/FlowCrypt/src/main/res/values/strings.xml
+++ b/FlowCrypt/src/main/res/values/strings.xml
@@ -653,6 +653,7 @@
     <string name="draft">Draft</string>
     <string name="delete_draft">Delete draft?</string>
     <string name="thread_was_deleted_or_moved">The thread was deleted or moved</string>
+    <string name="file_already_exists_in_download">\'%1$s\' already exists in Download. Would you like to download it again?</string>
     <plurals name="drafts_count">
         <item quantity="one">Draft</item>
         <item quantity="other">Drafts(%1$d)</item>

--- a/FlowCrypt/src/main/res/xml/preferences_general_settings.xml
+++ b/FlowCrypt/src/main/res/xml/preferences_general_settings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+  ~ Contributors: denbond7
+  -->
+
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:key="attachments_category"
+        app:title="@string/attachments">
+
+        <SwitchPreference
+            app:iconSpaceReserved="false"
+            app:key="@string/preferences_key_attachments_disable_smart_mode_for_preview"
+            app:title="@string/disable_smart_mode_for_attachments_preview" />
+
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/FlowCrypt/src/main/res/xml/preferences_main_settings.xml
+++ b/FlowCrypt/src/main/res/xml/preferences_main_settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
-  ~ Contributors: DenBond7
+  ~ Contributors: denbond7
   -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
@@ -50,6 +50,12 @@
         android:key="@string/pref_key_legal"
         android:title="@string/legal"
         app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="@string/pref_key_general"
+        android:title="@string/general"
+        app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false" />
 
     <Preference
         android:key="@string/pref_key_experimental"


### PR DESCRIPTION
This PR improved handling attachments. 

1. Added the ability to use any app to preview attachments for users who have a problem with a common approach.

Doesn't affect users with existing `RESTRICT_ANDROID_ATTACHMENT_HANDLING` policy.

https://github.com/user-attachments/assets/450c984d-1e47-4700-b5cb-eaae69147fff

Added a test to cover the following case: Test visibility for `Settings -> General` when `RESTRICT_ANDROID_ATTACHMENT_HANDLING` is present and vice versa.

As intents are handled by the system, it's hard to test 'smart mode' via Espresso(outside of the app scope). Tested manually.

2. Fixed the issue with a wrong name for duplicated downloads.

close #2894
close #2944
----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated
--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
