### PR TITLE
quotes for the plain text version + refactoring for #2957

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/extensions/com/google/api/services/gmail/model/ThreadExt.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/extensions/com/google/api/services/gmail/model/ThreadExt.kt
@@ -20,9 +20,10 @@ import jakarta.mail.internet.InternetAddress
  */
 fun Thread.getUniqueRecipients(account: String): List<InternetAddress> {
   return mutableListOf<InternetAddress>().apply {
-    if (messages == null || messages.isEmpty()) {
+    if (messages.isNullOrEmpty()) {
       return@apply
     }
+
     val fromHeaderName = "From"
 
     val filteredHeaders = if (messages.size > 1) {
@@ -42,7 +43,7 @@ fun Thread.getUniqueRecipients(account: String): List<InternetAddress> {
         } else emptyList()
       }.ifEmpty {
         //otherwise we will use all recipients
-        messages.flatMap { message -> message.filterHeadersWithName(fromHeaderName) }
+        messages.flatMap { it.filterHeadersWithName(fromHeaderName) }
       }
     } else {
       messages.first().filterHeadersWithName(fromHeaderName)

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/security/pgp/PgpMsg.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/security/pgp/PgpMsg.kt
@@ -1270,13 +1270,6 @@ object PgpMsg {
       msgContentAsText.append("[image: ${alt}]\n")
     }
 
-    /*blockquote:nth-child(even){ *//*for first blockquote *//*
-      border-left: 1px solid red; margin: 0px 0px 0px 10px; padding:10px 0px 0px 10px;
-    }
-    blockquote:nth-child(odd){ *//*for second blockquote *//*
-      border-left: 1px solid #31a217; margin: 0px 0px 0px 10px; padding:10px 0px 0px 10px;
-    }*/
-
     return FormattedContentBlockResult(
       text = msgContentAsText.toString().trim(),
       contentBlock = MsgBlockFactory.fromContent(

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/security/pgp/PgpMsg.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/security/pgp/PgpMsg.kt
@@ -531,7 +531,7 @@ object PgpMsg {
     if (dirtyHtml == null) return null
 
     val originalDocument = Jsoup.parse(dirtyHtml, "", Parser.xmlParser())
-    originalDocument.select("div.gmail_quote").firstOrNull()?.let { element ->
+    originalDocument.select("div.gmail_quote,div.flowcrypt_quote").firstOrNull()?.let { element ->
       //we wrap Gmail quote with 'details' tag
       val generation = Element("details").apply {
         appendChild(Element("summary"))
@@ -1357,7 +1357,7 @@ object PgpMsg {
       } else {
         appendChild(
           Element(tagDiv).apply {
-            attr("class", "gmail_quote")
+            attr("class", "flowcrypt_quote")
             //for better UI experience we need to extract the quote header of the first quote
             //and add it separately
             val quotesHeader =


### PR DESCRIPTION
This PR fixed quotes for the plain text version + refactoring for #2957

close #2961

### How to test:

1. Use a web client to create a conversation
2. Create a message via `recipientA`
3. Use `Plain` mode (not `HTML`) and send a message to `recipientB`
4. Open a message via `recipientB` and reply via `Plain` mode
5.  Open a message via `recipientA` and check quotes

![image](https://github.com/user-attachments/assets/5c2fa650-0550-4ca5-baa2-041bbd2f1d6c)


----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated (Added only JUnit test. UI test is impossible as we can't get `HTML` from `WebView` via `Espresso`).

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
