### PR TITLE
Fixed a case when Notifications keep coming even after settings option to load "Encrypted only" messages

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/gmail/GmailHistoryHandler.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/api/email/gmail/GmailHistoryHandler.kt
@@ -154,7 +154,9 @@ object GmailHistoryHandler {
         localFolder = localFolder,
         threads = uniqueThreadIdList.map { Thread().apply { id = it } },
         format = GmailApiHelper.RESPONSE_FORMAT_FULL
-      )
+      ).run {
+        takeIf { accountEntity.showOnlyEncrypted != true } ?: filter { it.hasPgpThings }
+      }
 
       val threadsToBeAdded = gmailThreadInfoList
         .filter { it.id !in existingThreadIds }
@@ -274,9 +276,7 @@ object GmailHistoryHandler {
         context, accountEntity,
         newCandidates.toList(), localFolder
       ).run {
-        if (accountEntity.showOnlyEncrypted == true) {
-          filter { it.hasPgp() }
-        } else this
+        takeIf { accountEntity.showOnlyEncrypted != true } ?: filter { it.hasPgp() }
       }
 
       val draftIdsMap = if (localFolder.isDrafts) {

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/jetpack/workmanager/sync/SyncDraftsWorker.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/jetpack/workmanager/sync/SyncDraftsWorker.kt
@@ -72,7 +72,7 @@ class SyncDraftsWorker(context: Context, params: WorkerParameters) :
         label = folderDrafts.fullName,
         msgsList = msgs,
         isNew = false,
-        onlyPgpModeEnabled = accountEntity.showOnlyEncrypted ?: false,
+        onlyPgpModeEnabled = accountEntity.showOnlyEncrypted == true,
         draftIdsMap = newDrafts.associateBy({ it.message.id }, { it.id })
       )
 

--- a/FlowCrypt/src/main/java/com/flowcrypt/email/service/MessagesNotificationManager.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/service/MessagesNotificationManager.kt
@@ -105,7 +105,7 @@ class MessagesNotificationManager(context: Context) : CustomNotificationManager(
           SharedPreferencesHelper.getString(
             PreferenceManager.getDefaultSharedPreferences(context),
             Constants.PREF_KEY_MESSAGES_NOTIFICATION_FILTER, ""
-          )
+          ) || account.showOnlyEncrypted == true
 
     val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     prepareAndShowMsgGroup(context, account, localFolder, manager, msgs)
@@ -170,7 +170,7 @@ class MessagesNotificationManager(context: Context) : CustomNotificationManager(
           SharedPreferencesHelper.getString(
             PreferenceManager.getDefaultSharedPreferences(context),
             Constants.PREF_KEY_MESSAGES_NOTIFICATION_FILTER, ""
-          )
+          ) || account.showOnlyEncrypted == true
 
     if (isEncryptedModeEnabled) {
       var isEncryptedMsgFound = false


### PR DESCRIPTION
This PR Fixed a case when Notifications keep coming even after settings option to load "Encrypted only" messages

close #2996

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why): this scenario can be tested when the app is in the background and threads syncing runs once per 15 minutes. It is hard(maybe not possible) to create a UI test using Espresso. Tested manually.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
