### PR TITLE
Enabled AttachmentDownloadingWithRestrictionFlowTest.| #3036

### DIFF
--- a/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/AttachmentDownloadingWithRestrictionFlowTest.kt
+++ b/FlowCrypt/src/androidTest/java/com/flowcrypt/email/ui/AttachmentDownloadingWithRestrictionFlowTest.kt
@@ -46,7 +46,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Ignore
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
@@ -165,7 +164,6 @@ class AttachmentDownloadingWithRestrictionFlowTest : BaseMessageDetailsFlowTest(
     .around(ScreenshotTestRule())
 
   @Test
-  @Ignore("will be fixed in https://github.com/FlowCrypt/flowcrypt-android/issues/2914")
   fun testDownloadingAttachment() {
     val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
@@ -215,7 +213,7 @@ class AttachmentDownloadingWithRestrictionFlowTest : BaseMessageDetailsFlowTest(
       //open notification and check we have "End Pass Phrase Session" button
       device.openNotification()
       device.wait(
-        Until.hasObject(By.text(requireNotNull(simpleAttInfo?.name))),
+        Until.hasObject(By.text(requireNotNull(simpleAttInfo.name))),
         TimeUnit.SECONDS.toMillis(1)
       )
       device.pressBack()


### PR DESCRIPTION
This PR Enabled AttachmentDownloadingWithRestrictionFlowTest. 

AttachmentDownloadingWithRestrictionFlowTest passes

```
@RunWith(RepeatableAndroidJUnit4ClassRunner::class)
@RepeatableAndroidJUnit4ClassRunner.RepeatTest(50)
```

And looks like it is not flaky now. I've enabled it.

close #3036

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
