### PR TITLE
Updated SemaphoreCI to use SdkVersion to 36

### DIFF
--- a/script/ci-install-android-sdk.sh
+++ b/script/ci-install-android-sdk.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#
+# © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+# Contributors: denbond7
+#
+
 set -euxo pipefail
 
 if [[ -d ~/.android ]]
@@ -30,10 +35,10 @@ else
 
     # Install Android SDK
     (echo "yes" | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null | grep -v = || true)
-    ( sleep 5; echo "y" ) | (${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "platforms;android-34" > /dev/null | grep -v = || true)
+    ( sleep 5; echo "y" ) | (${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "platforms;android-36" > /dev/null | grep -v = || true)
     (${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "platform-tools" | grep -v = || true)
     (${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "emulator" | grep -v = || true)
-    (echo "y" | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "system-images;android-34;google_apis;x86_64" > /dev/null | grep -v = || true)
+    (echo "y" | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager "system-images;android-36;google_apis;x86_64" > /dev/null | grep -v = || true)
 fi
 
 #Uncomment this for debug

--- a/script/ci-setup-and-run-emulator.sh
+++ b/script/ci-setup-and-run-emulator.sh
@@ -7,7 +7,7 @@
 
 "$ANDROID_HOME/emulator/emulator" -accel-check
 avdmanager list devices #debug
-echo -ne '\n' | avdmanager -v create avd --name ci-emulator --package "system-images;android-34;google_apis;x86_64" --device 'pixel_5' --abi 'google_apis/x86_64'
+echo -ne '\n' | avdmanager -v create avd --name ci-emulator --package "system-images;android-36;google_apis;x86_64" --device 'pixel_5' --abi 'google_apis/x86_64'
 cat ~/.android/avd/ci-emulator.avd/config.ini
 # echo "hw.ramSize=3064"  >> ~/.android/avd/ci-emulator.avd/config.ini
 # cat ~/.android/avd/ci-emulator.avd/config.ini


### PR DESCRIPTION
This PR Updated SemaphoreCI to use SdkVersion to 36

close #3086 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)


--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
