### PR TITLE
Fix PGPainless key parameter validation setup

### DIFF
--- a/FlowCrypt/src/main/java/com/flowcrypt/email/FlowCryptApplication.kt
+++ b/FlowCrypt/src/main/java/com/flowcrypt/email/FlowCryptApplication.kt
@@ -8,6 +8,7 @@ package com.flowcrypt.email
 import android.app.Application
 import android.content.Context
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -85,12 +86,7 @@ class FlowCryptApplication : Application(), Configuration.Provider {
   }
 
   private fun setupPGPainless() {
-    PGPainless.setInstance(
-      PGPainless(algorithmPolicy = generatePGPainlessPolicy().apply {
-        //https://github.com/FlowCrypt/flowcrypt-android/issues/2111
-        PGPainless.getInstance().algorithmPolicy.enableKeyParameterValidation = true
-      })
-    )
+    PGPainless.setInstance(createPGPainlessInstance())
   }
 
   private fun setupGlobalSettingsForJavaMail() {
@@ -102,27 +98,6 @@ class FlowCryptApplication : Application(), Configuration.Provider {
   override fun attachBaseContext(base: Context) {
     super.attachBaseContext(base)
     initACRA()
-  }
-
-  /**
-   * Allow sha1 for all builds except enterprise. It's a temporary solution.
-   * More details here https://github.com/FlowCrypt/flowcrypt-android/issues/1478 and here
-   * https://github.com/pgpainless/pgpainless/issues/158
-   */
-  @Suppress("KotlinConstantConditions")
-  private fun generatePGPainlessPolicy(): Policy {
-    val isEnterpriseBuild = BuildConfig.FLAVOR == Constants.FLAVOR_NAME_ENTERPRISE
-    val strongPolicySince2022 = HashAlgorithmPolicy.static2022SignatureHashAlgorithmPolicy()
-    val policyBefore2022Standard =
-      HashAlgorithmPolicy.static2022RevocationSignatureHashAlgorithmPolicy()
-    return Policy.Builder(PGPainless.getInstance().algorithmPolicy)
-      .withDataSignatureHashAlgorithmPolicy(
-        if (isEnterpriseBuild) strongPolicySince2022 else policyBefore2022Standard
-      )
-      .withCertificationSignatureHashAlgorithmPolicy(
-        if (isEnterpriseBuild) strongPolicySince2022 else policyBefore2022Standard
-      )
-      .build()
   }
 
   private fun setupKeysStorage() {
@@ -284,6 +259,37 @@ class FlowCryptApplication : Application(), Configuration.Provider {
 
     override fun onStop(owner: LifecycleOwner) {
       isAppForegroundedInternal = false
+    }
+  }
+
+  companion object {
+    @VisibleForTesting
+    internal fun createPGPainlessInstance(): PGPainless {
+      return PGPainless(algorithmPolicy = generatePGPainlessPolicy().apply {
+        //https://github.com/FlowCrypt/flowcrypt-android/issues/2111
+        enableKeyParameterValidation = true
+      })
+    }
+
+    /**
+     * Allow sha1 for all builds except enterprise. It's a temporary solution.
+     * More details here https://github.com/FlowCrypt/flowcrypt-android/issues/1478 and here
+     * https://github.com/pgpainless/pgpainless/issues/158
+     */
+    @Suppress("KotlinConstantConditions")
+    private fun generatePGPainlessPolicy(): Policy {
+      val isEnterpriseBuild = BuildConfig.FLAVOR == Constants.FLAVOR_NAME_ENTERPRISE
+      val strongPolicySince2022 = HashAlgorithmPolicy.static2022SignatureHashAlgorithmPolicy()
+      val policyBefore2022Standard =
+        HashAlgorithmPolicy.static2022RevocationSignatureHashAlgorithmPolicy()
+      return Policy.Builder(PGPainless.getInstance().algorithmPolicy)
+        .withDataSignatureHashAlgorithmPolicy(
+          if (isEnterpriseBuild) strongPolicySince2022 else policyBefore2022Standard
+        )
+        .withCertificationSignatureHashAlgorithmPolicy(
+          if (isEnterpriseBuild) strongPolicySince2022 else policyBefore2022Standard
+        )
+        .build()
     }
   }
 }

--- a/FlowCrypt/src/test/java/com/flowcrypt/email/FlowCryptApplicationTest.kt
+++ b/FlowCrypt/src/test/java/com/flowcrypt/email/FlowCryptApplicationTest.kt
@@ -1,0 +1,21 @@
+/*
+ * © 2016-present FlowCrypt a.s. Limitations apply. Contact human@flowcrypt.com
+ * Contributors: denbond7
+ */
+
+package com.flowcrypt.email
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * @author Denys Bondarenko
+ */
+class FlowCryptApplicationTest {
+  @Test
+  fun testCreatePGPainlessInstanceEnablesKeyParameterValidation() {
+    val pgpainless = FlowCryptApplication.createPGPainlessInstance()
+
+    assertTrue(pgpainless.algorithmPolicy.enableKeyParameterValidation)
+  }
+}

--- a/FlowCrypt/src/test/java/com/flowcrypt/email/security/pgp/PgpKeyTest.kt
+++ b/FlowCrypt/src/test/java/com/flowcrypt/email/security/pgp/PgpKeyTest.kt
@@ -17,7 +17,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 import org.pgpainless.PGPainless
 import org.pgpainless.algorithm.HashAlgorithm
@@ -150,7 +149,6 @@ class PgpKeyTest {
   }
 
   @Test
-  @Ignore("temporary disabled due to https://github.com/pgpainless/pgpainless/issues/488")
   fun testPublicKey_Issue1358() {
     val keyText = TestUtil.readResourceAsString("pgp/keys/issue-1358.public.gpg-key")
     val actual = PgpKey.parseKeys(source = keyText)

--- a/FlowCrypt/src/test/java/com/flowcrypt/email/security/pgp/PgpKeyTest.kt
+++ b/FlowCrypt/src/test/java/com/flowcrypt/email/security/pgp/PgpKeyTest.kt
@@ -166,8 +166,11 @@ class PgpKeyTest {
 
   @Test
   fun testReadCorruptedPrivateKey() {
+    val originalPgpainless = PGPainless.getInstance()
     try {
-      PGPainless.getInstance().algorithmPolicy.enableKeyParameterValidation = true
+      PGPainless.setInstance(FlowCryptApplication.createPGPainlessInstance())
+      assertTrue(PGPainless.getInstance().algorithmPolicy.enableKeyParameterValidation)
+
       val encryptedKeyText =
         TestUtil.readResourceAsString("pgp/keys/issue-1669-corrupted.private.gpg-key")
       val passphrase = Passphrase.fromPassword("123")
@@ -175,7 +178,7 @@ class PgpKeyTest {
         PgpKey.checkSecretKeyIntegrity(encryptedKeyText, passphrase)
       }
     } finally {
-      PGPainless.getInstance().algorithmPolicy.enableKeyParameterValidation = false
+      PGPainless.setInstance(originalPgpainless)
     }
   }
 

--- a/FlowCrypt/src/test/java/com/flowcrypt/email/security/pgp/PgpKeyTest.kt
+++ b/FlowCrypt/src/test/java/com/flowcrypt/email/security/pgp/PgpKeyTest.kt
@@ -6,6 +6,7 @@
 package com.flowcrypt.email.security.pgp
 
 import com.flowcrypt.email.BuildConfig
+import com.flowcrypt.email.FlowCryptApplication
 import com.flowcrypt.email.security.model.Algo
 import com.flowcrypt.email.security.model.KeyId
 import com.flowcrypt.email.security.model.PgpKeyRingDetails
@@ -150,9 +151,17 @@ class PgpKeyTest {
 
   @Test
   fun testPublicKey_Issue1358() {
-    val keyText = TestUtil.readResourceAsString("pgp/keys/issue-1358.public.gpg-key")
-    val actual = PgpKey.parseKeys(source = keyText)
-    assertEquals(1, actual.getAllKeys().size)
+    val originalPgpainless = PGPainless.getInstance()
+    try {
+      PGPainless.setInstance(FlowCryptApplication.createPGPainlessInstance())
+      assertTrue(PGPainless.getInstance().algorithmPolicy.enableKeyParameterValidation)
+
+      val keyText = TestUtil.readResourceAsString("pgp/keys/issue-1358.public.gpg-key")
+      val actual = PgpKey.parseKeys(source = keyText)
+      assertEquals(1, actual.getAllKeys().size)
+    } finally {
+      PGPainless.setInstance(originalPgpainless)
+    }
   }
 
   @Test


### PR DESCRIPTION
his PR fixes the PGPainless initialization to enable key parameter validation on the policy assigned to the new global PGPainless instance.

Previously, the setup modified the policy of the old global instance, which was discarded immediately afterward. As a result, key parameter validation remained disabled.

The PR also:

- Adds a regression test for the production PGPainless configuration.
- Re-enables `testPublicKey_Issue1358()` after the resolution of [PGPainless issue #488](https://github.com/pgpainless/pgpainless/issues/488).
- Verifies that the issue 1358 public key can be parsed with production key parameter validation enabled.
- Restores the original global PGPainless instance after each test.

close #3253 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
